### PR TITLE
Add coverage for prvAddNewTaskToReadyList and vTaskCoreAffinitySet.

### DIFF
--- a/FreeRTOS/Test/CMock/smp/Makefile
+++ b/FreeRTOS/Test/CMock/smp/Makefile
@@ -8,6 +8,7 @@ include ../makefile.in
 SUITES	+=	single_priority_no_timeslice
 SUITES	+=	single_priority_timeslice
 SUITES	+=	multiple_priorities_no_timeslice
+SUITES	+=	task_creation_covg
 # PROJECT and SUITE variables are determined based on path like so:
 #   $(UT_ROOT_DIR)/$(PROJECT)/$(SUITE)
 PROJECT :=  $(lastword $(subst /, ,$(dir $(abspath $(MAKEFILE_ABSPATH)))))

--- a/FreeRTOS/Test/CMock/smp/task_creation_covg/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/task_creation_covg/FreeRTOSConfig.h
@@ -1,0 +1,156 @@
+/*
+ * FreeRTOS V202112.00
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include "fake_assert.h"
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.  See
+* https://www.FreeRTOS.org/a00110.html
+*----------------------------------------------------------*/
+
+/* SMP test specific configuration */
+#define configRUN_MULTIPLE_PRIORITIES                    1
+#define configNUMBER_OF_CORES                            16
+#define configUSE_CORE_AFFINITY                          1
+#define configUSE_TIME_SLICING                           0
+#define configUSE_TASK_PREEMPTION_DISABLE                1
+#define configTICK_CORE                                  0
+
+/* OS Configuration */
+#define configUSE_PREEMPTION                             1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION          0
+#define configUSE_IDLE_HOOK                              0
+#define configUSE_TICK_HOOK                              0
+#define configUSE_DAEMON_TASK_STARTUP_HOOK               1
+#define configTICK_RATE_HZ                               ( 1000 )
+#define configMINIMAL_STACK_SIZE                         ( ( unsigned short ) 70 )
+#define configTOTAL_HEAP_SIZE                            ( ( size_t ) ( 52 * 1024 ) )
+#define configMAX_TASK_NAME_LEN                          ( 12 )
+#define configUSE_TRACE_FACILITY                         1
+#define configUSE_16_BIT_TICKS                           0
+#define configIDLE_SHOULD_YIELD                          1
+#define configUSE_MUTEXES                                1
+#define configCHECK_FOR_STACK_OVERFLOW                   0
+#define configUSE_RECURSIVE_MUTEXES                      1
+#define configQUEUE_REGISTRY_SIZE                        20
+#define configUSE_MALLOC_FAILED_HOOK                     1
+#define configUSE_APPLICATION_TASK_TAG                   1
+#define configUSE_COUNTING_SEMAPHORES                    1
+#define configUSE_ALTERNATIVE_API                        0
+#define configUSE_QUEUE_SETS                             1
+#define configUSE_TASK_NOTIFICATIONS                     1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES            5
+#define configSUPPORT_STATIC_ALLOCATION                  0
+#define configINITIAL_TICK_COUNT                         ( ( TickType_t ) 0 )
+#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    1
+#define portREMOVE_STATIC_QUALIFIER                      1
+#define portCRITICAL_NESTING_IN_TCB                      1
+#define portSTACK_GROWTH                                 ( 1 )
+#define configUSE_MINIMAL_IDLE_HOOK                      0
+
+/* Software timer related configuration options. */
+#define configUSE_TIMERS                                 1
+#define configTIMER_TASK_PRIORITY                        ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                         20
+#define configTIMER_TASK_STACK_DEPTH                     ( configMINIMAL_STACK_SIZE * 2 )
+
+#define configMAX_PRIORITIES                             ( 7 )
+
+/* Run time stats gathering configuration options. */
+unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
+void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that initialises the run time counter. */
+#define configGENERATE_RUN_TIME_STATS    0
+#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+#define portUSING_MPU_WRAPPERS                    0
+#define portHAS_STACK_OVERFLOW_CHECKING           0
+#define configENABLE_MPU                          0
+
+/* Co-routine related configuration options. */
+#define configUSE_CO_ROUTINES                     0
+#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS      1
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function.  In most cases the linker will remove unused
+ * functions anyway. */
+#define INCLUDE_vTaskPrioritySet                  1
+#define INCLUDE_uxTaskPriorityGet                 1
+#define INCLUDE_vTaskDelete                       1
+#define INCLUDE_vTaskCleanUpResources             0
+#define INCLUDE_vTaskSuspend                      1
+#define INCLUDE_vTaskDelayUntil                   1
+#define INCLUDE_vTaskDelay                        1
+#define INCLUDE_uxTaskGetStackHighWaterMark       1
+#define INCLUDE_xTaskGetSchedulerState            1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle    1
+#define INCLUDE_xTaskGetIdleTaskHandle            1
+#define INCLUDE_xTaskGetCurrentTaskHandle         1
+#define INCLUDE_xTaskGetHandle                    1
+#define INCLUDE_eTaskGetState                     1
+#define INCLUDE_xSemaphoreGetMutexHolder          1
+#define INCLUDE_xTimerPendFunctionCall            1
+#define INCLUDE_xTaskAbortDelay                   1
+#define INCLUDE_xTaskGetCurrentTaskHandle         1
+
+/* It is a good idea to define configASSERT() while developing.  configASSERT()
+ * uses the same semantics as the standard C assert() macro. */
+#define configASSERT( x )                             \
+    do                                                \
+    {                                                 \
+        if( x )                                       \
+        {                                             \
+            vFakeAssert( true, __FILE__, __LINE__ );  \
+        }                                             \
+        else                                          \
+        {                                             \
+            vFakeAssert( false, __FILE__, __LINE__ ); \
+        }                                             \
+    } while( 0 )
+
+#define mtCOVERAGE_TEST_MARKER()    __asm volatile ( "NOP" )
+
+#define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO    0
+#if ( configINCLUDE_MESSAGE_BUFFER_AMP_DEMO == 1 )
+    extern void vGenerateCoreBInterrupt( void * xUpdatedMessageBuffer );
+    #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
+#endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
+
+#endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Test/CMock/smp/task_creation_covg/Makefile
+++ b/FreeRTOS/Test/CMock/smp/task_creation_covg/Makefile
@@ -1,0 +1,47 @@
+# indent with spaces
+.RECIPEPREFIX := $(.RECIPEPREFIX) $(.RECIPEPREFIX)
+
+# Do not move this line below the include
+MAKEFILE_ABSPATH    :=  $(abspath $(lastword $(MAKEFILE_LIST)))
+include ../../makefile.in
+
+# PROJECT_SRC lists the .c files under test
+PROJECT_SRC         :=  tasks.c
+
+# PROJECT_DEPS_SRC list the .c file that are dependencies of PROJECT_SRC files
+# Files in PROJECT_DEPS_SRC are excluded from coverage measurements
+PROJECT_DEPS_SRC    := list.c queue.c
+
+# PROJECT_HEADER_DEPS: headers that should be excluded from coverage measurements.
+PROJECT_HEADER_DEPS :=  FreeRTOS.h
+
+# SUITE_UT_SRC: .c files that contain test cases (must end in _utest.c)
+SUITE_UT_SRC        :=  task_creation_covg_utest.c
+
+# SUITE_SUPPORT_SRC: .c files used for testing that do not contain test cases.
+# Paths are relative to PROJECT_DIR
+SUITE_SUPPORT_SRC   := smp_utest_common.c
+
+# List the headers used by PROJECT_SRC that you would like to mock
+MOCK_FILES_FP   +=  $(KERNEL_DIR)/include/timers.h
+MOCK_FILES_FP   +=  $(UT_ROOT_DIR)/config/fake_assert.h
+MOCK_FILES_FP   +=  $(UT_ROOT_DIR)/config/fake_port.h
+
+# List any addiitonal flags needed by the preprocessor
+CPPFLAGS            +=
+
+# List any addiitonal flags needed by the compiler
+CFLAGS              +=
+
+# Try not to edit beyond this line unless necessary.
+
+# Project is determined based on path: $(UT_ROOT_DIR)/$(PROJECT)
+PROJECT         :=  $(lastword $(subst /, ,$(dir $(abspath $(MAKEFILE_ABSPATH)/../))))
+SUITE           :=  $(lastword $(subst /, ,$(dir $(MAKEFILE_ABSPATH))))
+
+# Make variables available to included makefile
+export
+
+include ../../testdir.mk
+
+

--- a/FreeRTOS/Test/CMock/smp/task_creation_covg/task_creation_covg_utest.c
+++ b/FreeRTOS/Test/CMock/smp/task_creation_covg/task_creation_covg_utest.c
@@ -1,0 +1,335 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+/*! @file task_creation_covg_utest */
+
+/* C runtime includes. */
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Task includes */
+#include "FreeRTOS.h"
+#include "FreeRTOSConfig.h"
+#include "event_groups.h"
+#include "queue.h"
+//#include "portasm.h"
+
+/* Test includes. */
+#include "unity.h"
+#include "unity_memory.h"
+#include "../global_vars.h"
+#include "../smp_utest_common.h"
+
+/* Mock includes. */
+#include "mock_timers.h"
+#include "mock_fake_assert.h"
+#include "mock_fake_port.h"
+
+
+/* ===========================  EXTERN VARIABLES  =========================== */
+extern volatile UBaseType_t uxDeletedTasksWaitingCleanUp;
+extern volatile UBaseType_t uxSchedulerSuspended;
+extern volatile TCB_t *  pxCurrentTCBs[ configNUMBER_OF_CORES ];
+extern volatile BaseType_t xSchedulerRunning;
+extern volatile TickType_t xTickCount;
+extern volatile UBaseType_t uxCurrentNumberOfTasks;
+
+/* ==============================  Global VARIABLES ============================== */
+TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+
+/* ============================  Unity Fixtures  ============================ */
+/*! called before each testcase */
+void setUp( void )
+{
+    commonSetUp();
+}
+
+/*! called after each testcase */
+void tearDown( void )
+{
+    commonTearDown();
+}
+
+/*! called at the beginning of the whole suite */
+void suiteSetUp()
+{
+}
+
+/*! called at the end of the whole suite */
+int suiteTearDown( int numFailures )
+{
+    return numFailures;
+}
+
+/* ===========================  EXTERN FUNCTIONS  =========================== */
+extern void vTaskEnterCritical(void);
+
+/* ==============================  Helper functions for Test Cases  ============================== */
+
+
+/* ==============================  Test Cases  ============================== */
+
+/*
+The kernel will be configured as follows:
+    #define configNUMBER_OF_CORES                           (N > 1)
+    #define configUSE_CORE_AFFINITY                         1
+    #define configUSE_TASK_PREEMPTION_DISABLE               1
+
+Coverage for
+    static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
+    covers the case where the task being created is not the first or only task.
+*/
+void test_create_two_tasks_with_the_first_suspended( void )
+{
+    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0] );
+    vTaskSuspend(xTaskHandles[0]);
+
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[1] );
+
+    vTaskStartScheduler();
+}
+
+/*
+The kernel will be configured as follows:
+    #define configNUMBER_OF_CORES                           (N > 1)
+    #define configUSE_CORE_AFFINITY                         1
+    #define configUSE_TASK_PREEMPTION_DISABLE               1
+
+Coverage for
+    static void prvAddNewTaskToReadyList( TCB_t * pxNewTCB )
+    covers the case where there coreID is out of bounds when looking for a TCB
+
+Notes:
+    The prvAddNewTaskToReadyList function contained a subsection that is called
+    when the scheudler is not active. Furthermore it contains a loop which
+    is called only when the IDLE attribute of a task is set. As new tasks do not begin
+    with the IDLE attribute set, combined with the use of break on finding a free slot
+    and the entrance paths not calling the function in a way wich will reach the
+    for loops boundary condition. It is not currently reachable. One potential
+    fix would be to create new tasks with the IDLE attribute set when the scheduler
+    if not active. The other simple approach would be to avoid the break in the for
+    loop, but that would waste soe cycles. This note remains until a solution
+    is found.
+*/
+
+void show_task_status( void )
+{
+    UBaseType_t uxIdx;
+
+    for(uxIdx=0; uxIdx < configNUMBER_OF_CORES; uxIdx++)
+    {
+        if (pxCurrentTCBs[uxIdx] != NULL)
+        {
+            printf("    [%d]: 0x%lX\n", (int)uxIdx, pxCurrentTCBs[uxIdx]->uxTaskAttributes);
+        }
+    }
+}
+
+void test_create_more_tasks_than_there_are_cores( void )
+{
+    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES+3] = { NULL };
+
+    UBaseType_t uxTaskNum;
+
+    for(uxTaskNum=0; uxTaskNum <= configNUMBER_OF_CORES+1; uxTaskNum++)
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[uxTaskNum]);
+        printf("uxCurrentNumberOfTasks: %d, uxTaskNum=%d\n", (int)uxCurrentNumberOfTasks, (int)uxTaskNum);
+        show_task_status();
+        vTaskPreemptionDisable( xTaskHandles[uxTaskNum] );
+    }
+
+    //TEST_ASSERT_EQUAL( configNUMBER_OF_CORES, uxCurrentNumberOfTasks );
+    printf("ALL TASKS RUNNING:\n");
+    printf("uxCurrentNumberOfTasks: %d, uxTaskNum=%d\n", (int)uxCurrentNumberOfTasks, (int)configNUMBER_OF_CORES+2);
+    show_task_status();
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[configNUMBER_OF_CORES+2]);
+    printf("xTaskHandles[%d]: 0x%lX\n", (int)configNUMBER_OF_CORES+2, xTaskHandles[configNUMBER_OF_CORES+2]->uxTaskAttributes);
+
+    vTaskStartScheduler();
+
+    show_task_status();
+}
+
+/*
+The kernel will be configured as follows:
+    #define configNUMBER_OF_CORES                           (N > 1)
+    #define configUSE_CORE_AFFINITY                         1
+
+Coverage for
+    void vTaskCoreAffinitySet( const TaskHandle_t xTask, UBaseType_t uxCoreAffinityMask )
+    covers the case where vTaskCoreAffinitySet is called with NULL being passed to xTask
+    implicitly referring to the current task.
+*/
+
+
+void test_task_core_affinity_set_task_implied( void )
+{
+    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    UBaseType_t xidx;
+
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0] );
+
+    vTaskStartScheduler();
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+
+    vTaskCoreAffinitySet(NULL, (UBaseType_t)0xFF);
+}
+
+/*
+The kernel will be configured as follows:
+    #define configNUMBER_OF_CORES                           (N > 1)
+    #define configUSE_CORE_AFFINITY                         1
+
+Coverage for
+    void vTaskCoreAffinitySet( const TaskHandle_t xTask, UBaseType_t uxCoreAffinityMask )
+    covers the case where vTaskCoreAffinitySet is called with NULL being passed to xTask 
+    implicitly referring to the current task.
+*/
+
+void test_task_core_affinity_set_task_explicit( void )
+{
+    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0]);
+    vTaskCoreAffinitySet(xTaskHandles[0], (UBaseType_t)0xFF);
+
+    vTaskStartScheduler();
+}
+
+/*
+The kernel will be configured as follows:
+    #define configNUMBER_OF_CORES                           (N > 1)
+    #define configUSE_CORE_AFFINITY                         1
+
+Coverage for
+    void vTaskCoreAffinitySet( const TaskHandle_t xTask, UBaseType_t uxCoreAffinityMask )
+    covers the case where the affinity mask no longer includes the current core, triggering a yield
+*/
+
+void test_task_core_affinity_change_while_running( void )
+{
+    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    UBaseType_t xidx;
+
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0]);
+    vTaskCoreAffinitySet(xTaskHandles[0], (UBaseType_t)0x1);
+
+    vTaskStartScheduler();
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+
+    vTaskCoreAffinitySet(xTaskHandles[0], (UBaseType_t)0x2);
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+}
+
+/*
+The kernel will be configured as follows:
+    #define configNUMBER_OF_CORES                           (N > 1)
+    #define configUSE_CORE_AFFINITY                         1
+
+Coverage for
+    void vTaskCoreAffinitySet( const TaskHandle_t xTask, UBaseType_t uxCoreAffinityMask )
+    Changes the affinity of a suspended task such that it must yield on the core
+    it was originally running.
+*/
+
+void test_task_core_affinity_change_while_suspended( void )
+{
+    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    UBaseType_t xidx;
+
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0]);
+    vTaskCoreAffinitySet(xTaskHandles[0], (UBaseType_t)0x1);
+
+    vTaskStartScheduler();
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+
+    vTaskSuspend(xTaskHandles[0]);
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+
+    vTaskCoreAffinitySet(xTaskHandles[0], (UBaseType_t)0x2);
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+
+    vTaskCoreAffinitySet(xTaskHandles[0], (UBaseType_t)0x2);
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+}
+
+/*
+The kernel will be configured as follows:
+    #define configNUMBER_OF_CORES                           (N > 1)
+    #define configUSE_CORE_AFFINITY                         1
+
+Coverage for
+    void vTaskCoreAffinitySet( const TaskHandle_t xTask, UBaseType_t uxCoreAffinityMask )
+    Given #define taskTASK_IS_RUNNING( pxTCB )     ( ( pxTCB->xTaskRunState >= 0 ) && ( pxTCB->xTaskRunState < configNUMBER_OF_CORES ) )
+    Call the above macro where the second expression evaluates to false.
+*/
+
+void test_task_core_affinity_set_with_invalid_running_core( void )
+{
+    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    UBaseType_t xidx;
+
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0] );
+    vTaskCoreAffinitySet(xTaskHandles[0], (UBaseType_t)0x1);
+
+    vTaskStartScheduler();
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+
+    xTaskHandles[0]->xTaskRunState = configNUMBER_OF_CORES+1;
+    vTaskCoreAffinitySet(xTaskHandles[0], (UBaseType_t)0x2);
+
+    for (xidx = 0; xidx < configNUMBER_OF_CORES ; xidx++) {
+        xTaskIncrementTick_helper();
+    }
+}


### PR DESCRIPTION
<!--- Title -->

Add coverage tests for the functions mentioned in the title.
-----------
Add a subdirectory task_creation_covg to FreeRTOS/Test/CMock/smp/ and update the Makefile to include it in the list of test suites.

Note that one test, test_create_more_tasks_than_there_are_cores() does not currently reach one branch of a for loop. I think the functions static keywork may need to be removed so that a mock function can access it.

Test Steps
-----------
From the FreeRTOS/Test/CMock/smp subdirectory run 'make' against the default target followed by running 'make lcovhtml' to generate an HTML coverage report.

Related Issue
-----------
TS-24171, TS-24181


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
