### PR TITLE
Add coverage test for prvSelectHighestPriorityTask

### DIFF
--- a/FreeRTOS/Test/CMock/smp/global_vars.h
+++ b/FreeRTOS/Test/CMock/smp/global_vars.h
@@ -36,6 +36,9 @@
 /* Indicates that the task is actively running but scheduled to yield. */
 #define taskTASK_YIELDING       ( TaskRunning_t ) ( -2 )
 
+/* Indicates that the task is an Idle task. */
+#define taskATTRIBUTE_IS_IDLE    ( UBaseType_t ) ( 1UL << 0UL )
+
 typedef BaseType_t TaskRunning_t;
 
 typedef struct tskTaskControlBlock       /* The old naming convention is used to prevent breaking kernel aware debuggers. */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -1574,11 +1574,11 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_preemption_disabled( vo
     /* Validations.*/
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. Task on core 1 is yielding. */
-    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
     /* T1 is still running on core 1 since it has preemption disabled. */
-    TEST_ASSERT( pxCurrentTCBs[ 1 ] == &xTaskTCBs[ 1 ] );
+    TEST_ASSERT_EQUAL( &xTaskTCBs[ 1 ], pxCurrentTCBs[ 1 ] );
     /* TN+1 is selected to run on core 0. */
-    TEST_ASSERT( xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState == 0 );
+    TEST_ASSERT_EQUAL( 0, xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState );
 }
 
 /**

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c
@@ -384,11 +384,11 @@ void test_coverage_prvSelectHighestPriorityTask_not_schedule_none_idle_task( voi
     /* Validations.*/
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it is not an idle task and top priority is higher than idle. */
-    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
     /* T1 is not running since other idle task will be selected first. */
-    TEST_ASSERT( xTaskTCBs[ 0 ].xTaskRunState == taskTASK_NOT_RUNNING );
+    TEST_ASSERT_EQUAL( taskTASK_NOT_RUNNING, xTaskTCBs[ 0 ].xTaskRunState );
     /* T2 is selected to run on core 0. */
-    TEST_ASSERT( xTaskTCBs[ 2 ].xTaskRunState == 0 );
+    TEST_ASSERT_EQUAL( 0, xTaskTCBs[ 2 ].xTaskRunState );
 }
 
 /* @brief prvSelectHighestPriorityTask - yield for previous task with core affinity.
@@ -474,11 +474,11 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_yielding( void )
     /* Validations.*/
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. Task on core 1 is yielding. */
-    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
     /* T1 is still running on core 1 since it is yielding. */
-    TEST_ASSERT( pxCurrentTCBs[ 1 ] == &xTaskTCBs[ 1 ] );
+    TEST_ASSERT_EQUAL( &xTaskTCBs[ 1 ], pxCurrentTCBs[ 1 ] );
     /* TN+1 is selected to run on core 0. */
-    TEST_ASSERT( xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState == 0 );
+    TEST_ASSERT_EQUAL( 0, xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState );
 }
 
 /* @brief prvSelectHighestPriorityTask - yield for previous task with core affinity.
@@ -564,9 +564,9 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_state_invalid( voi
     /* Validations.*/
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. */
-    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
     /* TN+1 is selected to run on core 0. */
-    TEST_ASSERT( xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState == 0 );
+    TEST_ASSERT_EQUAL( 0, xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState );
 }
 
 /* @brief prvSelectHighestPriorityTask - yield for previous task with core affinity.
@@ -652,9 +652,9 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_yield_pending( voi
     /* Validations.*/
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. Core 1 has yield pending. */
-    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
     /* T1 is still running on core 1 since it has yield pending. */
-    TEST_ASSERT( pxCurrentTCBs[ 1 ] == &xTaskTCBs[ 1 ] );
+    TEST_ASSERT_EQUAL( &xTaskTCBs[ 1 ], pxCurrentTCBs[ 1 ] );
     /* TN+1 is selected to run on core 0. */
-    TEST_ASSERT( xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState == 0 );
+    TEST_ASSERT_EQUAL( 0, xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState );
 }

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c
@@ -54,10 +54,14 @@ extern volatile UBaseType_t uxDeletedTasksWaitingCleanUp;
 extern volatile TCB_t * pxCurrentTCBs[ configNUMBER_OF_CORES ];
 extern UBaseType_t uxTopReadyPriority;
 extern List_t pxReadyTasksLists[ configMAX_PRIORITIES ];
+extern BaseType_t xSchedulerRunning;
+extern UBaseType_t uxCurrentNumberOfTasks;
+extern volatile BaseType_t xYieldPendings[ configNUMBER_OF_CORES ];
 
 /* ===========================  EXTERN FUNCTIONS  =========================== */
 extern void prvIdleTask( void );
 extern void prvMinimalIdleTask( void );
+extern void prvSelectHighestPriorityTask( BaseType_t xCoreID );
 
 /* ============================  Unity Fixtures  ============================ */
 /*! called before each testcase */
@@ -86,6 +90,38 @@ int suiteTearDown( int numFailures )
 /* =============================  HELPER FUNCTIONS  ========================= */
 void vApplicationMinimalIdleHook( void )
 {
+}
+
+static void prvCreateStaticSMPTask( TaskHandle_t xTaskHandle,
+                                    UBaseType_t uxCoreAffinityMask,
+                                    UBaseType_t uxPriority,
+                                    BaseType_t xTaskRunState,
+                                    BaseType_t xTaskIsIdle )
+{
+    TCB_t * pxTaskTCB = ( TCB_t * )xTaskHandle;
+
+    pxTaskTCB->xStateListItem.pvOwner = pxTaskTCB;
+    pxTaskTCB->uxCoreAffinityMask = uxCoreAffinityMask;
+    pxTaskTCB->uxPriority = uxPriority;
+
+    if( ( xTaskRunState >= 0 ) && ( xTaskRunState < configNUMBER_OF_CORES ) )
+    {
+         pxCurrentTCBs[ xTaskRunState ] = pxTaskTCB;
+    }
+    pxTaskTCB->xTaskRunState = xTaskRunState;
+
+    pxTaskTCB->xStateListItem.pxContainer = &pxReadyTasksLists[ uxPriority ];
+    listINSERT_END( &pxReadyTasksLists[ uxPriority ], &pxTaskTCB->xStateListItem );
+
+    if( xTaskIsIdle == pdTRUE )
+    {
+        pxTaskTCB->uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+    }
+    else
+    {
+        pxTaskTCB->uxTaskAttributes = 0;
+    }
+    uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 }
 
 /* ==============================  Test Cases  ============================== */
@@ -308,4 +344,339 @@ void test_coverage_prvMinimalIdleTask_yield_for_idle_priority_task( void )
 
     /* Validations. xTaskTCBs[ i ] runs on core 0. */
     configASSERT( pxCurrentTCBs[ 0 ] == &xTaskTCBs[ i ] );
+}
+
+/* @brief prvSelectHighestPriorityTask - not schedule none idle task.
+ *
+ * Verify that none idle task can't be scheduled when there is higher priority task
+ * running with single priority config.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * if( uxCurrentPriority < uxTopReadyPriority )
+ * {
+ *     if( ( pxTCB->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) == 0 )
+ *     {
+ *         continue;
+ *     }
+ * }
+ * @endcode
+ * ( ( pxTCB->uxTaskAttributes & taskATTRIBUTE_IS_IDLE ) == 0 ) is true.
+ */
+void test_coverage_prvSelectHighestPriorityTask_not_schedule_none_idle_task( void )
+{
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES + 2U ] = { 0 };
+    uint32_t i = 0;
+
+    /* Setup the variables and structure. */
+    /* Initialize the idle priority ready list and set top ready priority to higher
+     * priority than idle. */
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ] ) );
+    uxTopReadyPriority = tskIDLE_PRIORITY + 1;
+    uxCurrentNumberOfTasks = 0;
+
+    /* Create one normal task to be inserted at the beginning of ready list. */
+    prvCreateStaticSMPTask( &xTaskTCBs[ 0 ],
+                            ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                            tskIDLE_PRIORITY,
+                            taskTASK_NOT_RUNNING,
+                            pdFALSE );
+
+    /* Create core numbers running idle task. */
+    for( i = 1; i < ( configNUMBER_OF_CORES + 1 ); i++ )
+    {
+        prvCreateStaticSMPTask( &xTaskTCBs[ i ],
+                                ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                tskIDLE_PRIORITY,
+                                ( i - 1 ),
+                                pdTRUE );
+    }
+
+    /* Create one higher priority normal task running on core one. */
+    prvCreateStaticSMPTask( &xTaskTCBs[ i ],
+                            ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                            tskIDLE_PRIORITY + 1,
+                            1,
+                            pdFALSE );
+    /* The original core 1 idle task now is not running. */
+    xTaskTCBs[ 2 ].xTaskRunState = taskTASK_NOT_RUNNING;
+
+    /* The ready list has the following status.
+     * Ready list [ 0 ] : T0, T1(0), T2, ..., TN(N-1).
+     * Ready list [ 1 ] : TN+1(1). */
+
+    /* API calls. Select task for core 0. */
+    prvSelectHighestPriorityTask( 0 );
+
+    /* Validations.*/
+    /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
+     * it is not an idle task and top priority is higher than idle. */
+    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    /* T1 is not running since other idle task will be selected first. */
+    TEST_ASSERT( xTaskTCBs[ 0 ].xTaskRunState == taskTASK_NOT_RUNNING );
+    /* T2 is selected to run on core 0. */
+    TEST_ASSERT( xTaskTCBs[ 2 ].xTaskRunState == 0 );
+}
+
+/* @brief prvSelectHighestPriorityTask - yield for previous task with core affinity.
+ *
+ * prvSelectHighestPriorityTask selects a task to run on specified core. The scheduler
+ * also selects another core to yield for previous task if the condition is satisfied.
+ * This test verifies the coverage of taskTASK_YIELDING condition.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * if( ( xTaskPriority < xLowestPriority ) &&
+ *     ( taskTASK_IS_RUNNING( pxCurrentTCBs[ uxCore ] ) != pdFALSE ) &&
+ *     ( xYieldPendings[ uxCore ] == pdFALSE ) )
+ * {
+ *     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+ *         if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == pdFALSE )
+ *     #endif
+ *     {
+ *         xLowestPriority = xTaskPriority;
+ *         xLowestPriorityCore = uxCore;
+ *     }
+ * }
+ * @endcode
+ * ( taskTASK_IS_RUNNING( pxCurrentTCBs[ uxCore ] ) != pdFALSE ) is false.
+ */
+void test_coverage_prvSelectHighestPriorityTask_affinity_task_yielding( void )
+{
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES + 2 ] = { 0 };
+    uint32_t i = 0;
+
+    /* Setup the variables and structure. */
+    /* Initialize the idle priority ready list and set top ready priority to higher
+     * priority than idle. */
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ] ) );
+    uxTopReadyPriority = tskIDLE_PRIORITY + 1;
+    uxCurrentNumberOfTasks = 0;
+
+    /* Create core numbers running idle task. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        prvCreateStaticSMPTask( &xTaskTCBs[ i ],
+                                ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                tskIDLE_PRIORITY,
+                                i,
+                                pdTRUE );
+    }
+
+    /* Create two higher priority normal task. */
+    for( i = configNUMBER_OF_CORES; i < ( configNUMBER_OF_CORES + 2 ); i++ )
+    {
+        prvCreateStaticSMPTask( &xTaskTCBs[ i ],
+                                ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                tskIDLE_PRIORITY + 1,
+                                taskTASK_NOT_RUNNING,
+                                pdFALSE );
+    }
+
+    /* Core 0 runs task TN. The original core 0 idle task now is not running. */
+    xTaskTCBs[ 0 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ configNUMBER_OF_CORES ];
+    xTaskTCBs[ configNUMBER_OF_CORES ].xTaskRunState = 0;
+
+    /* Idle task 1 is yielding. */
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_YIELDING;
+
+    /* Setup the affinity mask for TN and TN+1. */
+    xTaskTCBs[ configNUMBER_OF_CORES ].uxCoreAffinityMask = ( 1 << 0 ) | ( 1 << 1 );
+    xTaskTCBs[ configNUMBER_OF_CORES + 1 ].uxCoreAffinityMask = ( 1 << 0 );
+
+    /* The ready list has the following status.
+     * Ready list [ 0 ] : T0, T1(yielding), T2(2), ..., TN-1(N-1).
+     * Ready list [ 1 ] : TN(0), TN+1. */
+
+    /* API calls. Select task for core 0. Task TN+1 will be selected. Scheduler
+     * tries to find another core to yield for TN. The affinity mask limited the
+     * core for TN to run on core 1 only ( core 0 is running TN+1 ). Idle task 1 is
+     * yielding. Therefore, no core will yield for TN. */
+    prvSelectHighestPriorityTask( 0 );
+
+    /* Validations.*/
+    /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
+     * it can only runs on core 0 and core 1. Task on core 1 is yielding. */
+    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    /* T1 is still running on core 1 since it is yielding. */
+    TEST_ASSERT( pxCurrentTCBs[ 1 ] == &xTaskTCBs[ 1 ] );
+    /* TN+1 is selected to run on core 0. */
+    TEST_ASSERT( xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState == 0 );
+}
+
+/* @brief prvSelectHighestPriorityTask - yield for previous task with core affinity.
+ *
+ * prvSelectHighestPriorityTask selects a task to run on specified core. The scheduler
+ * also selects another core to yield for previous task if the condition is satisfied.
+ * This test verifies the coverage of invalid run state condition.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * if( ( xTaskPriority < xLowestPriority ) &&
+ *     ( taskTASK_IS_RUNNING( pxCurrentTCBs[ uxCore ] ) != pdFALSE ) &&
+ *     ( xYieldPendings[ uxCore ] == pdFALSE ) )
+ * {
+ *     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+ *         if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == pdFALSE )
+ *     #endif
+ *     {
+ *         xLowestPriority = xTaskPriority;
+ *         xLowestPriorityCore = uxCore;
+ *     }
+ * }
+ * @endcode
+ * ( taskTASK_IS_RUNNING( pxCurrentTCBs[ uxCore ] ) != pdFALSE ) is false.
+ */
+void test_coverage_prvSelectHighestPriorityTask_affinity_task_state_invalid( void )
+{
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES + 2 ] = { 0 };
+    uint32_t i = 0;
+
+    /* Setup the variables and structure. */
+    /* Initialize the idle priority ready list and set top ready priority to higher
+     * priority than idle. */
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ] ) );
+    uxTopReadyPriority = tskIDLE_PRIORITY + 1;
+    uxCurrentNumberOfTasks = 0;
+
+    /* Create core numbers running idle task. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        prvCreateStaticSMPTask( &xTaskTCBs[ i ],
+                                ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                tskIDLE_PRIORITY,
+                                i,
+                                pdTRUE );
+    }
+
+    /* Create two higher priority normal task. */
+    for( i = configNUMBER_OF_CORES; i < ( configNUMBER_OF_CORES + 2 ); i++ )
+    {
+        prvCreateStaticSMPTask( &xTaskTCBs[ i ],
+                                ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                tskIDLE_PRIORITY + 1,
+                                taskTASK_NOT_RUNNING,
+                                pdFALSE );
+    }
+
+    /* Core 0 runs task TN. The original core 0 idle task now is not running. */
+    xTaskTCBs[ 0 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ configNUMBER_OF_CORES ];
+    xTaskTCBs[ configNUMBER_OF_CORES ].xTaskRunState = 0;
+
+    /* Idle task 1 is of invalid run state. */
+    xTaskTCBs[ 1 ].xTaskRunState = configNUMBER_OF_CORES;
+
+    /* Setup the affinity mask for TN and TN+1. */
+    xTaskTCBs[ configNUMBER_OF_CORES ].uxCoreAffinityMask = ( 1 << 0 ) | ( 1 << 1 );
+    xTaskTCBs[ configNUMBER_OF_CORES + 1 ].uxCoreAffinityMask = ( 1 << 0 );
+
+    /* The ready list has the following status.
+     * Ready list [ 0 ] : T0, T1(yielding), T2(2), ..., TN-1(N-1).
+     * Ready list [ 1 ] : TN(0), TN+1. */
+
+    /* API calls. Select task for core 0. Task TN+1 will be selected. Scheduler
+     * tries to find another core to yield for TN. The affinity mask limited the
+     * core for TN to run on core 1 only ( core 0 is running TN+1 ). Idle task 1 has
+     * invalid run state. Therefore, no core will yield for TN. */
+    prvSelectHighestPriorityTask( 0 );
+
+    /* Validations.*/
+    /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
+     * it can only runs on core 0 and core 1. */
+    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    /* TN+1 is selected to run on core 0. */
+    TEST_ASSERT( xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState == 0 );
+}
+
+/* @brief prvSelectHighestPriorityTask - yield for previous task with core affinity.
+ *
+ * prvSelectHighestPriorityTask selects a task to run on specified core. The scheduler
+ * also selects another core to yield for previous task if the condition is satisfied.
+ * This test verifies the coverage of yield pending condition.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * if( ( xTaskPriority < xLowestPriority ) &&
+ *     ( taskTASK_IS_RUNNING( pxCurrentTCBs[ uxCore ] ) != pdFALSE ) &&
+ *     ( xYieldPendings[ uxCore ] == pdFALSE ) )
+ * {
+ *     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+ *         if( pxCurrentTCBs[ uxCore ]->xPreemptionDisable == pdFALSE )
+ *     #endif
+ *     {
+ *         xLowestPriority = xTaskPriority;
+ *         xLowestPriorityCore = uxCore;
+ *     }
+ * }
+ * @endcode
+ * ( xYieldPendings[ uxCore ] == pdFALSE ) is false.
+ */
+void test_coverage_prvSelectHighestPriorityTask_affinity_task_yield_pending( void )
+{
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES + 2 ] = { 0 };
+    uint32_t i = 0;
+
+    /* Setup the variables and structure. */
+    /* Initialize the idle priority ready list and set top ready priority to higher
+     * priority than idle. */
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ] ) );
+    uxTopReadyPriority = tskIDLE_PRIORITY + 1;
+    uxCurrentNumberOfTasks = 0;
+
+    /* Create core numbers running idle task. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        prvCreateStaticSMPTask( &xTaskTCBs[ i ],
+                                ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                tskIDLE_PRIORITY,
+                                i,
+                                pdTRUE );
+    }
+
+    /* Create two higher priority normal task. */
+    for( i = configNUMBER_OF_CORES; i < ( configNUMBER_OF_CORES + 2 ); i++ )
+    {
+        prvCreateStaticSMPTask( &xTaskTCBs[ i ],
+                                ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                tskIDLE_PRIORITY + 1,
+                                taskTASK_NOT_RUNNING,
+                                pdFALSE );
+    }
+
+    /* Core 0 runs task TN. The original core 0 idle task now is not running. */
+    xTaskTCBs[ 0 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ configNUMBER_OF_CORES ];
+    xTaskTCBs[ configNUMBER_OF_CORES ].xTaskRunState = 0;
+
+    /* Core 1 has yield pending. */
+    xYieldPendings[ 1 ] = pdTRUE;
+
+    /* Setup the affinity mask for TN and TN+1. */
+    xTaskTCBs[ configNUMBER_OF_CORES ].uxCoreAffinityMask = ( 1 << 0 ) | ( 1 << 1 );
+    xTaskTCBs[ configNUMBER_OF_CORES + 1 ].uxCoreAffinityMask = ( 1 << 0 );
+
+    /* The ready list has the following status.
+     * Ready list [ 0 ] : T0, T1(yielding), T2(2), ..., TN-1(N-1).
+     * Ready list [ 1 ] : TN(0), TN+1. */
+
+    /* API calls. Select task for core 0. Task TN+1 will be selected. Scheduler
+     * tries to find another core to yield for TN. The affinity mask limited the
+     * core for TN to run on core 1 only ( core 0 is running TN+1 ). Core 1 has yield
+     * pending. Therefore, no core will yield for TN. */
+    prvSelectHighestPriorityTask( 0 );
+
+    /* Validations.*/
+    /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
+     * it can only runs on core 0 and core 1. Core 1 has yield pending. */
+    TEST_ASSERT( pxCurrentTCBs[ 0 ] != &xTaskTCBs[ 0 ] );
+    /* T1 is still running on core 1 since it has yield pending. */
+    TEST_ASSERT( pxCurrentTCBs[ 1 ] == &xTaskTCBs[ 1 ] );
+    /* TN+1 is selected to run on core 0. */
+    TEST_ASSERT( xTaskTCBs[ configNUMBER_OF_CORES + 1 ].xTaskRunState == 0 );
 }

--- a/FreeRTOS/Test/CMock/smp/smp_utest_common.c
+++ b/FreeRTOS/Test/CMock/smp/smp_utest_common.c
@@ -378,3 +378,45 @@ void xTaskIncrementTick_helper( void )
 
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptState );
 }
+
+#if ( configUSE_CORE_AFFINITY == 1 )
+    void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
+                                UBaseType_t uxCoreAffinityMask,
+                                UBaseType_t uxPriority,
+                                BaseType_t xTaskRunState,
+                                BaseType_t xTaskIsIdle )
+#else
+    void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
+                                UBaseType_t uxPriority,
+                                BaseType_t xTaskRunState,
+                                BaseType_t xTaskIsIdle )
+#endif
+{
+    TCB_t * pxTaskTCB = ( TCB_t * )xTaskHandle;
+
+    pxTaskTCB->xStateListItem.pvOwner = pxTaskTCB;
+    #if ( configUSE_CORE_AFFINITY == 1 )
+        pxTaskTCB->uxCoreAffinityMask = uxCoreAffinityMask;
+    #endif
+    pxTaskTCB->uxPriority = uxPriority;
+
+    /* Also assign pxCurrentTCBs to the created task. */
+    if( ( xTaskRunState >= 0 ) && ( xTaskRunState < configNUMBER_OF_CORES ) )
+    {
+         pxCurrentTCBs[ xTaskRunState ] = pxTaskTCB;
+    }
+    pxTaskTCB->xTaskRunState = xTaskRunState;
+
+    /* Set idle task attribute. */
+    if( xTaskIsIdle == pdTRUE )
+    {
+        pxTaskTCB->uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+    }
+    else
+    {
+        pxTaskTCB->uxTaskAttributes = 0;
+    }
+
+    /* Increase the uxCurrentNumberOfTasks. */
+    uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
+}

--- a/FreeRTOS/Test/CMock/smp/smp_utest_common.h
+++ b/FreeRTOS/Test/CMock/smp/smp_utest_common.h
@@ -96,4 +96,20 @@ void xTaskIncrementTick_helper( void );
  */
 void vSetCurrentCore( BaseType_t xCoreID );
 
+/**
+ * @brief Helper function to create static test task.
+ */
+#if ( configUSE_CORE_AFFINITY == 1 )
+    void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
+                                UBaseType_t uxCoreAffinityMask,
+                                UBaseType_t uxPriority,
+                                BaseType_t xTaskRunState,
+                                BaseType_t xTaskIsIdle );
+#else
+    void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
+                                UBaseType_t uxPriority,
+                                BaseType_t xTaskRunState,
+                                BaseType_t xTaskIsIdle );
+#endif
+
 #endif /* SMP_UTEST_COMMON_H */


### PR DESCRIPTION
Add coverage test for prvSelectHighestPriorityTask

Description
-----------
The following branches are not covered
* configASSERT - These branches will be covered in config_assert folder
* if( xTaskScheduled == pdTRUE ) - Consider to fix in the implementation
* if( taskVALID_CORE_ID( xLowestPriorityCore ) == pdTRUE ) - Consider to fix in the implementation

<html><body>
<!--StartFragment-->

Filename | -- | -- | Line Coverage | -- | Functions | -- | Branches | --
-- | -- | -- | -- | -- | -- | -- | -- | --
event_groups.c |   |   | 95.4 % | 167 / 175 | 100.0 % | 15 / 15 | 70.2 % | 66 / 94
list.c |   |   | 100.0 % | 40 / 40 | 100.0 % | 5 / 5 | 100.0 % | 6 / 6
queue.c |   |   | 95.3 % | 710 / 745 | 100.0 % | 46 / 46 | 97.0 % | 446 / 460
stream_buffer.c |   |   | 94.0 % | 300 / 319 | 100.0 % | 25 / 25 | 94.8 % | 182 / 192
tasks.c |   |   | 97.7 % | 1407 / 1440 | 100.0 % | 95 / 95 | 90.9 % | 925 / 1018
timers.c |   |   | 100.0 % | 237 / 237 | 100.0 % | 29 / 29 | 96.1 % | 74 / 77

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
