### PR TITLE
Add coverage test for xTaskRemoveFromEventList and vTaskRemoveFromUnorderedEventList

### DIFF
--- a/FreeRTOS/Test/CMock/smp/global_vars.h
+++ b/FreeRTOS/Test/CMock/smp/global_vars.h
@@ -30,6 +30,9 @@
 
 #include <stdbool.h>
 
+/* Indicates that the task is an Idle task. */
+#define taskATTRIBUTE_IS_IDLE    ( UBaseType_t ) ( 1UL << 0UL )
+
 /* Indicates that the task is not actively running on any core. */
 #define taskTASK_NOT_RUNNING    ( TaskRunning_t ) ( -1 )
 

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -58,6 +58,9 @@ extern volatile TickType_t xTickCount;
 extern List_t pxReadyTasksLists[ configMAX_PRIORITIES ];
 extern volatile UBaseType_t uxTopReadyPriority;
 extern volatile BaseType_t xYieldPendings[ configNUMBER_OF_CORES ];
+extern List_t xSuspendedTaskList;
+extern List_t * volatile pxDelayedTaskList;
+extern List_t xDelayedTaskList1;
 
 /* ===========================  EXTERN FUNCTIONS  =========================== */
 extern void prvAddNewTaskToReadyList( TCB_t * pxNewTCB );
@@ -1179,4 +1182,293 @@ void test_coverage_prvYieldForTask_task_yield_pending( void )
     {
         TEST_ASSERT( xYieldPendings[ i ] != pdTRUE );
     }
+}
+
+/**
+ * @brief xTaskRemoveFromEventList - Remove a equal priority task from event list.
+ *
+ * The task is removed from event list. Verified this task is put back to ready list 
+ * and removed from event list. Current core is not requested to yield.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * #else
+ * {
+ *     xReturn = pdFALSE;
+ *
+ *     #if ( configUSE_PREEMPTION == 1 )
+ *     {
+ *         prvYieldForTask( pxUnblockedTCB );
+ *
+ *         if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
+ *         {
+ *             xReturn = pdTRUE;
+ *         }
+ *     }
+ *     #endif
+ * }
+ * #endif
+ * @endcode
+ * ( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE ) is false.
+ */
+void test_coverage_xTaskRemoveFromEventList_remove_eq_priority_task( void )
+{
+    TCB_t xTaskTCB = { NULL };
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
+    List_t xEventList = { 0 };
+    uint32_t i;
+    BaseType_t xReturn;
+
+    /* Setup the variables and structure. */
+    uxSchedulerSuspended = pdFALSE;
+    uxTopReadyPriority = tskIDLE_PRIORITY;
+    vListInitialise( &xEventList );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &xSuspendedTaskList );
+    vListInitialise( &xDelayedTaskList1 );
+    pxDelayedTaskList = &xDelayedTaskList1;
+
+    /* Create idle tasks and add it into the ready list. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
+        xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+        xTaskTCBs[ i ].uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+
+        /* Create idle tasks with equal number of cores. */
+        pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].xTaskRunState = i;
+        xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
+        listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
+        uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
+    }
+
+    /* Create one more task to be removed from event list. */
+    xTaskTCB.uxPriority = tskIDLE_PRIORITY;
+    xTaskTCB.xStateListItem.pxContainer = &xSuspendedTaskList;
+    xTaskTCB.xStateListItem.pvOwner = &xTaskTCB;
+    listINSERT_END( &xSuspendedTaskList, &xTaskTCB.xStateListItem );
+    xTaskTCB.xEventListItem.pxContainer = &xEventList;
+    xTaskTCB.xEventListItem.pvOwner = &xTaskTCB;
+    listINSERT_END( &xEventList, &xTaskTCB.xEventListItem );
+    xTaskTCB.xTaskRunState = taskTASK_NOT_RUNNING;
+    xTaskTCB.uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+    uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
+
+    /* Expectations. */
+    vFakePortGetCoreID_StubWithCallback( NULL );
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get prvYieldCore. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get xYieldPendings. */
+
+    /* API call. */
+    xReturn = xTaskRemoveFromEventList( &xEventList );
+
+    /* Validations. */
+    /* Yield not required for current core due to equal priority. */
+    TEST_ASSERT_EQUAL( xReturn, pdFALSE );
+    /* Task is removed from event list. */
+    TEST_ASSERT_EQUAL( xTaskTCB.xEventListItem.pvContainer, NULL );
+    /* Task is added to ready list. */
+    TEST_ASSERT_EQUAL( xTaskTCB.xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCB.uxPriority ] );
+}
+
+/**
+ * @brief xTaskRemoveFromEventList - Remove a higher priority task from event list.
+ *
+ * The task is removed from event list. Verified this task is put back to ready list
+ * and removed from event list. Current core is requested to yield.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * #else
+ * {
+ *     xReturn = pdFALSE;
+ *
+ *     #if ( configUSE_PREEMPTION == 1 )
+ *     {
+ *         prvYieldForTask( pxUnblockedTCB );
+ *
+ *         if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
+ *         {
+ *             xReturn = pdTRUE;
+ *         }
+ *     }
+ *     #endif
+ * }
+ * #endif
+ * @endcode
+ * ( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE ) is true.
+ */
+void test_coverage_xTaskRemoveFromEventList_remove_higher_priority_task( void )
+{
+    TCB_t xTaskTCB = { NULL };
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
+    List_t xEventList = { 0 };
+    uint32_t i;
+    BaseType_t xReturn;
+
+    /* Setup the variables and structure. */
+    uxSchedulerSuspended = pdFALSE;
+    uxTopReadyPriority = tskIDLE_PRIORITY + 1U;
+    vListInitialise( &xEventList );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1U ] ) );
+    vListInitialise( &xSuspendedTaskList );
+    vListInitialise( &xDelayedTaskList1 );
+    pxDelayedTaskList = &xDelayedTaskList1;
+
+    /* Create idle tasks and add it into the ready list. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
+        xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+        if( i == 0 )
+        {
+            /* Core 0 is running an idle task in order to be requested to yield. */
+            xTaskTCBs[ i ].uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+        }
+        else
+        {
+            /* Others are running a normal task. */
+            xTaskTCBs[ i ].uxTaskAttributes = 0;
+        }
+
+        /* Create idle tasks with equal number of cores. */
+        pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].xTaskRunState = i;
+        xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
+        listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
+        uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
+    }
+
+    /* Create one more task to be removed from event list. */
+    xTaskTCB.uxPriority = tskIDLE_PRIORITY + 1U;
+    xTaskTCB.xStateListItem.pxContainer = &xSuspendedTaskList;
+    xTaskTCB.xStateListItem.pvOwner = &xTaskTCB;
+    listINSERT_END( &xSuspendedTaskList, &xTaskTCB.xStateListItem );
+    xTaskTCB.xEventListItem.pxContainer = &xEventList;
+    xTaskTCB.xEventListItem.pvOwner = &xTaskTCB;
+    listINSERT_END( &xEventList, &xTaskTCB.xEventListItem );
+    xTaskTCB.xTaskRunState = taskTASK_NOT_RUNNING;
+    xTaskTCB.uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+    uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
+
+    /* Expectations. */
+    vFakePortGetCoreID_StubWithCallback( NULL );
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get prvYieldCore. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get xYieldPendings. */
+
+    /* API call. */
+    xReturn = xTaskRemoveFromEventList( &xEventList );
+
+    /* Validations. */
+    /* Yield is required for current core due to higher priority. */
+    TEST_ASSERT_EQUAL( xReturn, pdTRUE );
+    /* Task is removed from event list. */
+    TEST_ASSERT_EQUAL( xTaskTCB.xEventListItem.pvContainer, NULL );
+    /* Task is added to ready list. */
+    TEST_ASSERT_EQUAL( xTaskTCB.xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCB.uxPriority ] );
+}
+
+
+/**
+ * @brief vTaskRemoveFromUnorderedEventList - Remove a higher priority task from event list.
+ *
+ * The task is removed from event list. Verified this task is put back to ready list
+ * and removed from event list. Current core is requested to yield. The item value
+ * is set correctly.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * #else
+ * {
+ *     #if ( configUSE_PREEMPTION == 1 )
+ *     {
+ *         taskENTER_CRITICAL();
+ *         {
+ *             prvYieldForTask( pxUnblockedTCB );
+ *         }
+ *         taskEXIT_CRITICAL();
+ *     }
+ *     #endif
+ * }
+ * #endif
+ * @endcode
+ */
+void test_coverage_vTaskRemoveFromUnorderedEventList_remove_higher_priority_task( void )
+{
+    TCB_t xTaskTCB = { NULL };
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
+    List_t xEventList = { 0 };
+    uint32_t i;
+
+    /* Setup the variables and structure. */
+    uxSchedulerSuspended = pdFALSE;
+    uxTopReadyPriority = tskIDLE_PRIORITY + 1U;
+    vListInitialise( &xEventList );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1U ] ) );
+    vListInitialise( &xSuspendedTaskList );
+    vListInitialise( &xDelayedTaskList1 );
+    pxDelayedTaskList = &xDelayedTaskList1;
+
+    /* Create idle tasks and add it into the ready list. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
+        xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+        if( i == 0 )
+        {
+            /* Core 0 is running an idle task in order to be requested to yield. */
+            xTaskTCBs[ i ].uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+        }
+        else
+        {
+            /* Others are running a normal task. */
+            xTaskTCBs[ i ].uxTaskAttributes = 0;
+        }
+
+        /* Create idle tasks with equal number of cores. */
+        pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].xTaskRunState = i;
+        xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
+        listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
+        uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
+    }
+
+    /* Create one more task to be removed from event list. */
+    xTaskTCB.uxPriority = tskIDLE_PRIORITY + 1U;
+    xTaskTCB.xStateListItem.pxContainer = &xSuspendedTaskList;
+    xTaskTCB.xStateListItem.pvOwner = &xTaskTCB;
+    listINSERT_END( &xSuspendedTaskList, &xTaskTCB.xStateListItem );
+    xTaskTCB.xEventListItem.pxContainer = &xEventList;
+    xTaskTCB.xEventListItem.pvOwner = &xTaskTCB;
+    listINSERT_END( &xEventList, &xTaskTCB.xEventListItem );
+    xTaskTCB.xTaskRunState = taskTASK_NOT_RUNNING;
+    xTaskTCB.uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+    uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
+
+    /* Expectations. */
+    vFakePortGetCoreID_StubWithCallback( NULL );
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get prvYieldCore. */
+
+    /* API call. */
+    vTaskRemoveFromUnorderedEventList( &xTaskTCB.xEventListItem, 500 | 0x80000000UL );
+
+    /* Validations. */
+    /* Task is removed from event list. */
+    TEST_ASSERT_EQUAL( xTaskTCB.xEventListItem.pvContainer, NULL );
+    /* Task is added to ready list. */
+    TEST_ASSERT_EQUAL( xTaskTCB.xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCB.uxPriority ] );
+    /* The event list item value is set. */
+    TEST_ASSERT_EQUAL( xTaskTCB.xEventListItem.xItemValue, 500 | 0x80000000UL );
+    /* The xYieldPendings is set. */
+    TEST_ASSERT_EQUAL( xYieldPendings[ 0 ] , pdTRUE );
 }

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -1268,11 +1268,11 @@ void test_coverage_xTaskRemoveFromEventList_remove_eq_priority_task( void )
 
     /* Validations. */
     /* Yield not required for current core due to equal priority. */
-    TEST_ASSERT_EQUAL( xReturn, pdFALSE );
+    TEST_ASSERT_EQUAL( pdFALSE, xReturn );
     /* Task is removed from event list. */
-    TEST_ASSERT_EQUAL( xTaskTCB.xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( NULL, xTaskTCB.xEventListItem.pvContainer );
     /* Task is added to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCB.xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCB.uxPriority ] );
+    TEST_ASSERT_EQUAL( &pxReadyTasksLists[ xTaskTCB.uxPriority ], xTaskTCB.xStateListItem.pvContainer );
 }
 
 /**
@@ -1368,11 +1368,11 @@ void test_coverage_xTaskRemoveFromEventList_remove_higher_priority_task( void )
 
     /* Validations. */
     /* Yield is required for current core due to higher priority. */
-    TEST_ASSERT_EQUAL( xReturn, pdTRUE );
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
     /* Task is removed from event list. */
-    TEST_ASSERT_EQUAL( xTaskTCB.xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( NULL, xTaskTCB.xEventListItem.pvContainer );
     /* Task is added to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCB.xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCB.uxPriority ] );
+    TEST_ASSERT_EQUAL( &pxReadyTasksLists[ xTaskTCB.uxPriority ], xTaskTCB.xStateListItem.pvContainer );
 }
 
 
@@ -1464,11 +1464,11 @@ void test_coverage_vTaskRemoveFromUnorderedEventList_remove_higher_priority_task
 
     /* Validations. */
     /* Task is removed from event list. */
-    TEST_ASSERT_EQUAL( xTaskTCB.xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( NULL, xTaskTCB.xEventListItem.pvContainer );
     /* Task is added to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCB.xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCB.uxPriority ] );
+    TEST_ASSERT_EQUAL( &pxReadyTasksLists[ xTaskTCB.uxPriority ], xTaskTCB.xStateListItem.pvContainer );
     /* The event list item value is set. */
-    TEST_ASSERT_EQUAL( xTaskTCB.xEventListItem.xItemValue, 500 | 0x80000000UL );
+    TEST_ASSERT_EQUAL( 500 | 0x80000000UL, xTaskTCB.xEventListItem.xItemValue );
     /* The xYieldPendings is set. */
-    TEST_ASSERT_EQUAL( xYieldPendings[ 0 ] , pdTRUE );
+    TEST_ASSERT_EQUAL( pdTRUE, xYieldPendings[ 0 ] );
 }


### PR DESCRIPTION
Add coverage test for xTaskRemoveFromEventList and vTaskRemoveFromUnorderedEventList

Description
-----------
Coverage rate 

Filename | -- | -- | Line Coverage | -- | Functions | -- | Branches | --
-- | -- | -- | -- | -- | -- | -- | -- | --
event_groups.c |   |   | 95.4 % | 167 / 175 | 100.0 % | 15 / 15 | 70.2 % | 66 / 94
list.c |   |   | 100.0 % | 40 / 40 | 100.0 % | 5 / 5 | 100.0 % | 6 / 6
queue.c |   |   | 95.3 % | 710 / 745 | 100.0 % | 46 / 46 | 97.0 % | 446 / 460
stream_buffer.c |   |   | 94.0 % | 300 / 319 | 100.0 % | 25 / 25 | 94.8 % | 182 / 192
tasks.c |   |   | 98.1 % | 1413 / 1440 | 100.0 % | 95 / 95 | 91.1 % | 927 / 1018
timers.c |   |   | 100.0 % | 237 / 237 | 100.0 % | 29 / 29 | 96.1 % | 74 / 77

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
