### PR TITLE
Add coverage test for xTaskGenericNotifyFromISR and vTaskGenericNotifyGiveFromISR

### DIFF
--- a/FreeRTOS/Test/CMock/smp/global_vars.h
+++ b/FreeRTOS/Test/CMock/smp/global_vars.h
@@ -30,11 +30,19 @@
 
 #include <stdbool.h>
 
+/* Indicates that the task is an Idle task. */
+#define taskATTRIBUTE_IS_IDLE    ( UBaseType_t ) ( 1UL << 0UL )
+
 /* Indicates that the task is not actively running on any core. */
 #define taskTASK_NOT_RUNNING    ( TaskRunning_t ) ( -1 )
 
 /* Indicates that the task is actively running but scheduled to yield. */
 #define taskTASK_YIELDING       ( TaskRunning_t ) ( -2 )
+
+/* Values that can be assigned to the ucNotifyState member of the TCB. */
+#define taskNOT_WAITING_NOTIFICATION              ( ( uint8_t ) 0 ) /* Must be zero as it is the initialised value. */
+#define taskWAITING_NOTIFICATION                  ( ( uint8_t ) 1 )
+#define taskNOTIFICATION_RECEIVED                 ( ( uint8_t ) 2 )
 
 typedef BaseType_t TaskRunning_t;
 

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -432,7 +432,7 @@ void test_coverage_uxTaskGetTaskNumber_task_handle( void )
     uxTaskNumber = uxTaskGetTaskNumber( &xTaskTCB );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( uxTaskNumber, 0x5a5a );
+    TEST_ASSERT_EQUAL( 0x5a5a, uxTaskNumber );
 }
 
 /**
@@ -462,7 +462,7 @@ void test_coverage_uxTaskGetTaskNumber_null_task_handle( void )
     uxTaskNumber = uxTaskGetTaskNumber( NULL );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( uxTaskNumber, 0U );
+    TEST_ASSERT_EQUAL( 0U, uxTaskNumber );
 }
 
 /**
@@ -488,10 +488,10 @@ void test_coverage_vTaskSetTaskNumber_task_handle( void )
     xTaskTCB.uxTaskNumber = 0;
 
     /* API call. */
-    vTaskSetTaskNumber( &xTaskTCB, 0x5a5a );
+    vTaskSetTaskNumber( 0x5a5a, &xTaskTCB );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xTaskTCB.uxTaskNumber, 0x5a5a );
+    TEST_ASSERT_EQUAL( 0x5a5a, xTaskTCB.uxTaskNumber );
 }
 
 /**
@@ -1272,7 +1272,7 @@ void test_coverage_vTaskEnterCritical_task_in_critical_already( void )
     vTaskEnterCritical();
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xTaskTCB.uxCriticalNesting, 2 );
+    TEST_ASSERT_EQUAL( 2, xTaskTCB.uxCriticalNesting );
 }
 
 /**
@@ -1312,8 +1312,8 @@ void test_coverage_vTaskEnterCriticalFromISR_isr_in_critical_already( void )
     uxSavedInterruptStatus = vTaskEnterCriticalFromISR();
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xTaskTCB.uxCriticalNesting, 2 );
-    TEST_ASSERT_EQUAL( uxSavedInterruptStatus, 0x5a5a );
+    TEST_ASSERT_EQUAL( 2, xTaskTCB.uxCriticalNesting );
+    TEST_ASSERT_EQUAL( 0X5a5a, uxSavedInterruptStatus );
 }
 
 /**
@@ -1356,7 +1356,7 @@ void test_coverage_vTaskExitCritical_task_enter_critical_mt_1( void )
     vTaskExitCritical();
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xTaskTCB.uxCriticalNesting, 1 );
+    TEST_ASSERT_EQUAL( 1, xTaskTCB.uxCriticalNesting );
 }
 
 /**
@@ -1455,7 +1455,7 @@ void test_coverage_vTaskExitCriticalFromISR_isr_enter_critical_mt_1( void )
     vTaskExitCriticalFromISR( 0x5a5a );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xTaskTCB.uxCriticalNesting, 1 );
+    TEST_ASSERT_EQUAL( 1, xTaskTCB.uxCriticalNesting );
 }
 
 /**
@@ -1593,9 +1593,9 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_le( void )
                                          &xHigherPriorityTaskWoken );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xReturn, pdTRUE );
-    TEST_ASSERT_EQUAL( ulPreviousNotificationValue, 0x5a5a );
-    TEST_ASSERT_NOT_EQUAL( xHigherPriorityTaskWoken, pdTRUE );
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+    TEST_ASSERT_EQUAL( 0x5a5a, ulPreviousNotificationValue );
+    TEST_ASSERT_NOT_EQUAL( pdTRUE, xHigherPriorityTaskWoken );
 }
 
 /**
@@ -1702,9 +1702,9 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_gt( void )
                                          &xHigherPriorityTaskWoken );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xReturn, pdTRUE );
-    TEST_ASSERT_EQUAL( ulPreviousNotificationValue, 0x5a5a );
-    TEST_ASSERT_EQUAL( xHigherPriorityTaskWoken, pdTRUE );
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+    TEST_ASSERT_EQUAL( 0x5a5a, ulPreviousNotificationValue );
+    TEST_ASSERT_EQUAL( pdTRUE, xHigherPriorityTaskWoken );
 }
 
 /**
@@ -1811,9 +1811,9 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_gt_null_param( void )
                                          NULL );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xReturn, pdTRUE );
-    TEST_ASSERT_EQUAL( ulPreviousNotificationValue, 0x5a5a );
-    TEST_ASSERT_EQUAL( xYieldPendings[ 0 ], pdTRUE );
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+    TEST_ASSERT_EQUAL( 0x5a5a, ulPreviousNotificationValue );
+    TEST_ASSERT_EQUAL( pdTRUE, xYieldPendings[ 0 ] );
 }
 
 /**
@@ -1904,8 +1904,8 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_le( void )
                                    &xHigherPriorityTaskWoken );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xTaskTCB.ulNotifiedValue[ uxIndexToNotify ], 0x5a5a + 1U );
-    TEST_ASSERT_NOT_EQUAL( xHigherPriorityTaskWoken, pdTRUE );
+    TEST_ASSERT_EQUAL( 0x5a5a + 1U, xTaskTCB.ulNotifiedValue[ uxIndexToNotify ] );
+    TEST_ASSERT_NOT_EQUAL( pdTRUE, xHigherPriorityTaskWoken );
 }
 
 /**
@@ -2007,8 +2007,8 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_gt( void )
                                    &xHigherPriorityTaskWoken );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xTaskTCB.ulNotifiedValue[ uxIndexToNotify ], 0x5a5a + 1U );
-    TEST_ASSERT_EQUAL( xHigherPriorityTaskWoken, pdTRUE );
+    TEST_ASSERT_EQUAL( 0x5a5a + 1U, xTaskTCB.ulNotifiedValue[ uxIndexToNotify ] );
+    TEST_ASSERT_EQUAL( pdTRUE, xHigherPriorityTaskWoken );
 }
 
 /**
@@ -2110,6 +2110,6 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_gt_null_param( void )
                                    NULL );
 
     /* Validation. */
-    TEST_ASSERT_EQUAL( xTaskTCB.ulNotifiedValue[ uxIndexToNotify ], 0x5a5a + 1U );
-    TEST_ASSERT_EQUAL( xYieldPendings[ 0 ], pdTRUE );
+    TEST_ASSERT_EQUAL( 0x5a5a + 1U, xTaskTCB.ulNotifiedValue[ uxIndexToNotify ] );
+    TEST_ASSERT_EQUAL( pdTRUE, xYieldPendings[ 0 ] );
 }

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -548,7 +548,7 @@ void test_coverage_vTaskSetTaskNumber_task_handle( void )
     xTaskTCB.uxTaskNumber = 0;
 
     /* API call. */
-    vTaskSetTaskNumber( 0x5a5a, &xTaskTCB );
+    vTaskSetTaskNumber( &xTaskTCB, 0x5a5a );
 
     /* Validation. */
     TEST_ASSERT_EQUAL( 0x5a5a, xTaskTCB.uxTaskNumber );


### PR DESCRIPTION
Add coverage test for xTaskGenericNotifyFromISR and vTaskGenericNotifyGiveFromISR

Description
-----------
* These two functions are similar. vTaskGenericNotifyGiveFromISR is the notify value increment version of xTaskGenericNotifyFromISR.

Filename | -- | -- | Line Coverage | -- | Functions | -- | Branches | --
-- | -- | -- | -- | -- | -- | -- | -- | --
event_groups.c |   |   | 95.4 % | 167 / 175 | 100.0 % | 15 / 15 | 70.2 % | 66 / 94
list.c |   |   | 100.0 % | 40 / 40 | 100.0 % | 5 / 5 | 100.0 % | 6 / 6
queue.c |   |   | 95.3 % | 710 / 745 | 100.0 % | 46 / 46 | 97.0 % | 446 / 460
stream_buffer.c |   |   | 94.0 % | 300 / 319 | 100.0 % | 25 / 25 | 94.8 % | 182 / 192
tasks.c |   |   | 98.2 % | 1414/ 1440| 100.0 % | 95 / 95 | 91.5 % | 931 / 1018
timers.c |   |   | 100.0 % | 237 / 237 | 100.0 % | 29 / 29 | 96.1 % | 74 / 77

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
