### PR TITLE
Add coverage test for prvCheckTasksWaitingTermination

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -1570,6 +1570,7 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_not_running_task( void
     TCB_t *pxTaskTCB = NULL;
 
     /* Setup the variables and structure. */
+    UnityMalloc_StartTest();
     uxDeletedTasksWaitingCleanUp = 1;
     uxCurrentNumberOfTasks = 1;
     vListInitialise( &xTasksWaitingTermination );
@@ -1595,6 +1596,8 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_not_running_task( void
     /* Validation. */
     TEST_ASSERT_EQUAL( uxCurrentNumberOfTasks, 0 );
     TEST_ASSERT_EQUAL( uxDeletedTasksWaitingCleanUp, 0 );
+    /* Validate the memory allocate count. */
+    UnityMalloc_EndTest();
 }
 
 /**
@@ -1625,6 +1628,7 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_running_task( void )
     TCB_t *pxTaskTCB = NULL;
 
     /* Setup the variables and structure. */
+    UnityMalloc_StartTest();
     uxDeletedTasksWaitingCleanUp = 1;
     uxCurrentNumberOfTasks = 1;
     vListInitialise( &xTasksWaitingTermination );
@@ -1649,5 +1653,15 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_running_task( void )
 
     /* Validation. */
     /* If the task is not of taskTASK_NOT_RUNNING state, nothing will be updated.
-     * This test shows it's result in coverage report. */
+     * This test shows it's result in coverage report. Verify that the number of
+     * deleted task is not changed. */
+    TEST_ASSERT_EQUAL( uxDeletedTasksWaitingCleanUp, 1 );
+    TEST_ASSERT_EQUAL( uxCurrentNumberOfTasks, 1 );
+
+    /* Free the resource allocated in this test. Since running task can't be deleted,
+     * there won't have double free assertion. */
+    vPortFree( pxTaskTCB );
+    vPortFree( pxTaskTCB->pxStack );
+    /* Validate the memory allocate count. */
+    UnityMalloc_EndTest();
 }

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -58,6 +58,7 @@ extern volatile TickType_t xTickCount;
 extern List_t pxReadyTasksLists[ configMAX_PRIORITIES ];
 extern volatile UBaseType_t uxTopReadyPriority;
 extern volatile BaseType_t xYieldPendings[ configNUMBER_OF_CORES ];
+extern List_t xTasksWaitingTermination;
 
 /* ===========================  EXTERN FUNCTIONS  =========================== */
 extern void prvAddNewTaskToReadyList( TCB_t * pxNewTCB );
@@ -66,6 +67,7 @@ extern void vTaskEnterCritical( void );
 extern UBaseType_t vTaskEnterCriticalFromISR( void );
 extern void vTaskExitCritical( void );
 extern void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
+extern void prvCheckTasksWaitingTermination( void );
 
 /* ==============================  Global VARIABLES ============================== */
 TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
@@ -94,11 +96,14 @@ int suiteTearDown( int numFailures )
     return numFailures;
 }
 
-/* ===========================  EXTERN FUNCTIONS  =========================== */
-extern void vTaskEnterCritical(void);
-
 /* ==============================  Helper functions for Test Cases  ============================== */
+static void prvPortEnterCriticalSectionCb( int cmock_num_calls )
+{
+    ( void ) cmock_num_calls;
 
+    /* This simulate the multiple idle tasks tries to clean the deleleted TCB. */
+    uxDeletedTasksWaitingCleanUp = 0;
+}
 
 /* ==============================  Test Cases  ============================== */
 
@@ -1497,4 +1502,152 @@ void test_coverage_vTaskExitCriticalFromISR_isr_not_in_critical( void )
     /* Validation. */
     /* Critical section count won't be changed. This test shows it's result in the
      * coverage report. */
+}
+
+/**
+ * @brief prvCheckTasksWaitingTermination - multiple idle tasks clean the deleted task.
+ *
+ * This test case cover the branch that the waiting termination tasks are already been
+ * deleted by other idle tasks.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * taskENTER_CRITICAL();
+ * {
+ *     ...
+ *     if( uxDeletedTasksWaitingCleanUp > ( UBaseType_t ) 0U )
+ *     {
+ *         pxTCB = listGET_OWNER_OF_HEAD_ENTRY( ( &xTasksWaitingTermination ) );
+ * @endcode
+ * ( uxDeletedTasksWaitingCleanUp > ( UBaseType_t ) 0U ) is false.
+ */
+void test_coverage_prvCheckTasksWaitingTermination_multiple_idle_tasks( void )
+{
+    /* Setup the variables and structure. */
+    uxDeletedTasksWaitingCleanUp = 1;
+
+    /* Clear callback in commonSetUp. */
+    vFakePortEnterCriticalSection_StubWithCallback( NULL );
+    vFakePortExitCriticalSection_StubWithCallback( NULL );
+
+    /* Expectations. */
+    vFakePortEnterCriticalSection_StubWithCallback( prvPortEnterCriticalSectionCb );
+    vFakePortExitCriticalSection_Expect();
+
+    /* API call. */
+    prvCheckTasksWaitingTermination();
+
+    /* Validation. */
+    /* No task is waiting to be cleand up. Nothing will be updated in this API. This
+     * test case shows its result in the coverage report. */
+}
+
+/**
+ * @brief prvCheckTasksWaitingTermination - delete not running task.
+ *
+ * A not running task is deleted. The number of tasks and number of tasks waiting to
+ * be deleted are verified in this test case.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * if( pxTCB->xTaskRunState == taskTASK_NOT_RUNNING )
+ * {
+ *     ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
+ *     --uxCurrentNumberOfTasks;
+ *     --uxDeletedTasksWaitingCleanUp;
+ * }
+ * else
+ * {
+ *     ...
+ *     taskEXIT_CRITICAL();
+ *     break;
+ * }
+ * @endcode
+ * ( pxTCB->xTaskRunState == taskTASK_NOT_RUNNING ) is true.
+ */
+void test_coverage_prvCheckTasksWaitingTermination_delete_not_running_task( void )
+{
+    TCB_t *pxTaskTCB = NULL;
+
+    /* Setup the variables and structure. */
+    uxDeletedTasksWaitingCleanUp = 1;
+    uxCurrentNumberOfTasks = 1;
+    vListInitialise( &xTasksWaitingTermination );
+
+    pxTaskTCB = pvPortMalloc( sizeof( TCB_t ) );
+    pxTaskTCB->pxStack = pvPortMalloc( configMINIMAL_STACK_SIZE );
+    pxTaskTCB->xTaskRunState = taskTASK_NOT_RUNNING ;
+    pxTaskTCB->xStateListItem.pvOwner = pxTaskTCB;
+    pxTaskTCB->xStateListItem.pxContainer = &xTasksWaitingTermination;
+    listINSERT_END( &xTasksWaitingTermination, &pxTaskTCB->xStateListItem );
+
+    /* Clear callback in commonSetUp. */
+    vFakePortEnterCriticalSection_StubWithCallback( NULL );
+    vFakePortExitCriticalSection_StubWithCallback( NULL );
+
+    /* Expectations. */
+    vFakePortEnterCriticalSection_Expect();
+    vFakePortExitCriticalSection_Expect();
+
+    /* API call. */
+    prvCheckTasksWaitingTermination();
+
+    /* Validation. */
+    TEST_ASSERT_EQUAL( uxCurrentNumberOfTasks, 0 );
+    TEST_ASSERT_EQUAL( uxDeletedTasksWaitingCleanUp, 0 );
+}
+
+/**
+ * @brief prvCheckTasksWaitingTermination - delete running task.
+ *
+ * A task to be deleted is still running. Nothing will be updated in this test case.
+ * The test shows it's result in the coverage report.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * if( pxTCB->xTaskRunState == taskTASK_NOT_RUNNING )
+ * {
+ *     ( void ) uxListRemove( &( pxTCB->xStateListItem ) );
+ *     --uxCurrentNumberOfTasks;
+ *     --uxDeletedTasksWaitingCleanUp;
+ * }
+ * else
+ * {
+ *     ...
+ *     taskEXIT_CRITICAL();
+ *     break;
+ * }
+ * @endcode
+ * ( pxTCB->xTaskRunState == taskTASK_NOT_RUNNING ) is false.
+ */
+void test_coverage_prvCheckTasksWaitingTermination_delete_running_task( void )
+{
+    TCB_t *pxTaskTCB = NULL;
+
+    /* Setup the variables and structure. */
+    uxDeletedTasksWaitingCleanUp = 1;
+    uxCurrentNumberOfTasks = 1;
+    vListInitialise( &xTasksWaitingTermination );
+
+    pxTaskTCB = pvPortMalloc( sizeof( TCB_t ) );
+    pxTaskTCB->pxStack = pvPortMalloc( configMINIMAL_STACK_SIZE );
+    pxTaskTCB->xTaskRunState = 0 ;
+    pxTaskTCB->xStateListItem.pvOwner = pxTaskTCB;
+    pxTaskTCB->xStateListItem.pxContainer = &xTasksWaitingTermination;
+    listINSERT_END( &xTasksWaitingTermination, &pxTaskTCB->xStateListItem );
+
+    /* Clear callback in commonSetUp. */
+    vFakePortEnterCriticalSection_StubWithCallback( NULL );
+    vFakePortExitCriticalSection_StubWithCallback( NULL );
+
+    /* Expectations. */
+    vFakePortEnterCriticalSection_Expect();
+    vFakePortExitCriticalSection_Expect();
+
+    /* API call. */
+    prvCheckTasksWaitingTermination();
+
+    /* Validation. */
+    /* If the task is not of taskTASK_NOT_RUNNING state, nothing will be updated.
+     * This test shows it's result in coverage report. */
 }

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -168,6 +168,9 @@ static int assertionFailed = 0;
  */
 static BaseType_t shouldAbortOnAssertion = pdFALSE;
 
+/* ============================  EXTERN FUNCTIONS  ========================== */
+extern void prvCheckTasksWaitingTermination( void );
+
 /* ============================  HOOK FUNCTIONS  ============================ */
 static void dummy_operation()
 {
@@ -1000,6 +1003,70 @@ void test_vTaskDelete_sucess_not_current_task_no_yield( void )
     ASSERT_PORT_YIELD_WITHIN_API_NOT_CALLED();
 }
 
+/**
+ * @brief prvCheckTasksWaitingTermination - no waiting task.
+ *
+ * No task is waiting to be deleted. This test show it's result in the coverage
+ * report.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * while( uxDeletedTasksWaitingCleanUp > ( UBaseType_t ) 0U )
+ * {
+ *     ...
+ * }
+ * @endcode
+ * ( uxDeletedTasksWaitingCleanUp > ( UBaseType_t ) 0U ) is false.
+ */
+void test_prvCheckTasksWaitingTermination_no_waiting_task( void )
+{
+    /* Setup the variables and structure. */
+    uxDeletedTasksWaitingCleanUp = 0;
+
+    /* API Call. */
+    prvCheckTasksWaitingTermination();
+
+    /* Validation. */
+    /* No task is waiting to be cleand up. Nothing will be updated in this API. This
+     * test case shows its result in the coverage report. */
+}
+
+/**
+ * @brief prvCheckTasksWaitingTermination - delete waiting task.
+ *
+ * A task is waiting to be deleted. The number of tasks and number of tasks waiting to
+ * be deleted are verified in this test case.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * while( uxDeletedTasksWaitingCleanUp > ( UBaseType_t ) 0U )
+ * {
+ *     ...
+ * }
+ * @endcode
+ * ( uxDeletedTasksWaitingCleanUp > ( UBaseType_t ) 0U ) is true.
+ */
+void test_prvCheckTasksWaitingTermination_delete_waiting_task( void )
+{
+    ptcb = ( TCB_t * ) create_task();
+
+    /* Setup the variables and structure. */
+    uxDeletedTasksWaitingCleanUp = 1;
+    uxCurrentNumberOfTasks = 1;
+
+    /* Expectations. */
+    listGET_OWNER_OF_HEAD_ENTRY_ExpectAnyArgsAndReturn( ptcb );
+    uxListRemove_ExpectAndReturn( &ptcb->xStateListItem, 0 );
+    vPortFree_Expect( stack );
+    vPortFree_Expect( ptcb );
+
+    /* API Call. */
+    prvCheckTasksWaitingTermination();
+
+    /* Validation. */
+    TEST_ASSERT_EQUAL( uxDeletedTasksWaitingCleanUp, 0 );
+    TEST_ASSERT_EQUAL( uxCurrentNumberOfTasks, 0 );
+}
 
 void test_vTaskStartScheduler_success( void )
 {


### PR DESCRIPTION
Add coverage test for prvCheckTasksWaitingTermination

Description
-----------
<html><body>
<!--StartFragment-->

Filename | -- | -- | Line Coverage | -- | Functions | -- | Branches | --
-- | -- | -- | -- | -- | -- | -- | -- | --
event_groups.c |   |   | 95.4 % | 167 / 175 | 100.0 % | 15 / 15 | 70.2 % | 66 / 94
list.c |   |   | 100.0 % | 40 / 40 | 100.0 % | 5 / 5 | 100.0 % | 6 / 6
queue.c |   |   | 95.3 % | 710 / 745 | 100.0 % | 46 / 46 | 97.0 % | 446 / 460
stream_buffer.c |   |   | 94.0 % | 300 / 319 | 100.0 % | 25 / 25 | 94.8 % | 182 / 192
tasks.c |   |   | 97.5 % | 1388 / 1423 | 100.0 % | 94 / 94 | 87.5 % | 886 / 1012
timers.c |   |   | 100.0 % | 237 / 237 | 100.0 % | 29 / 29 | 96.1 % | 74 / 77

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
