### PR TITLE
add branch coverage for vTaskResume and xTaskGenericNotify.

### DIFF
--- a/FreeRTOS/Test/CMock/smp/global_vars.h
+++ b/FreeRTOS/Test/CMock/smp/global_vars.h
@@ -30,6 +30,11 @@
 
 #include <stdbool.h>
 
+/* Values that can be assigned to the ucNotifyState member of the TCB. */
+#define taskNOT_WAITING_NOTIFICATION              ( ( uint8_t ) 0 ) /* Must be zero as it is the initialised value. */
+#define taskWAITING_NOTIFICATION                  ( ( uint8_t ) 1 )
+#define taskNOTIFICATION_RECEIVED                 ( ( uint8_t ) 2 )
+
 /* Indicates that the task is not actively running on any core. */
 #define taskTASK_NOT_RUNNING    ( TaskRunning_t ) ( -1 )
 

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -1505,16 +1505,18 @@ void test_coverage_vTaskExitCriticalFromISR_isr_not_in_critical( void )
  *
  * <b>Coverage</b>
  * @code{c}
- *                if( prvTaskIsTaskSuspended( pxTCB ) != pdFALSE )
- *                {
- *            ...
+ * if( pxTCB != NULL )
+ * {
+ *     ...
+ * }
  * @endcode
- *
- * Cover the case where a NULL task is specified.
+ * ( pxTCB != NULL ) is false.
  */
-void test_coverage_vTaskResume_null_task(void) {
+void test_coverage_vTaskResume_null_task( void )
+{
     vTaskResume(NULL);
-    /* in this case no state is changed and so no assertion can be made to
+
+    /* In this case no state is changed and so no assertion can be made to
      * validate the operation. */
 }
 
@@ -1523,9 +1525,9 @@ void test_coverage_vTaskResume_null_task(void) {
  *
  * <b>Coverage</b>
  * @code{c}
- *      if( ucOriginalNotifyState == taskWAITING_NOTIFICATION )
- *      {
- *          ...
+ * if( ucOriginalNotifyState == taskWAITING_NOTIFICATION )
+ * {
+ *     ...
  * @endcode
  *
  * Cover the case where the ucOriginalNotifyState is taskWAITING_NOTIFICATION.
@@ -1538,10 +1540,7 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
     BaseType_t xReturn;
     UBaseType_t uxPriority, uxCoreID;
 
-    for(
-        uxPriority = ( UBaseType_t ) 0U;
-        uxPriority < ( UBaseType_t ) configMAX_PRIORITIES;
-        uxPriority++)
+    for( uxPriority = ( UBaseType_t ) 0U; uxPriority < ( UBaseType_t ) configMAX_PRIORITIES; uxPriority++ )
     {
         vListInitialise( &( pxReadyTasksLists[ uxPriority ] ) );
     }
@@ -1553,17 +1552,15 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
     vListInitialiseItem( &( xTaskTCBs[0].xStateListItem ) );
     listSET_LIST_ITEM_OWNER( &( xTaskTCBs[0].xStateListItem ), &xTaskTCBs[0] );
     listINSERT_END( &xPendingReadyList, &xTaskTCBs[ 0 ].xStateListItem );
-    xYieldPendings[ portGET_CORE_ID() ] = pdFALSE;
-    pxCurrentTCBs[ portGET_CORE_ID() ] = &xTaskTCBs[ 0 ];
+
+    /* Default core ID is 0. The can be changed with vSetCurrentCore. */
+    xYieldPendings[ 0 ] = pdFALSE;
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
     xTaskTCBs[ 1 ].uxPriority = 1;
     xTaskTCBs[ 1 ].xTaskRunState = -1;
 
-    for(
-        uxCoreID = 0;
-        uxCoreID < configNUMBER_OF_CORES;
-        uxCoreID++
-    )
+    for( uxCoreID = 0; uxCoreID < configNUMBER_OF_CORES; uxCoreID++ )
     {
         if (pxCurrentTCBs[ uxCoreID ] == NULL)
         {
@@ -1573,10 +1570,11 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
 
     uxTopReadyPriority = 1;
     uxSchedulerSuspended = pdTRUE;
+    xTaskTCBs[0].ucNotifyState[ xidx ] = taskNOT_WAITING_NOTIFICATION;
+    xTaskTCBs[0].ulNotifiedValue[ xidx ] = 0xa5a5;      /* Value to be verified later. */
 
-    xTaskTCBs[0].ucNotifyState[ xidx ] = /*taskWAITING_NOTIFICATION*/ ( ( uint8_t ) 1 );
     xReturn = xTaskGenericNotify( &xTaskTCBs[0], xidx, 0x0, eNoAction, &prevValue);
 
-    TEST_ASSERT_EQUAL_UINT32(0x0, prevValue);
+    TEST_ASSERT_EQUAL_UINT32( 0xa5a5, prevValue );
     TEST_ASSERT( xReturn == pdPASS );
 }


### PR DESCRIPTION
add branch coverage for vTaskResume and xTaskGenericNotify.

Description
-----------
update covg_multiple_priorities_no_timeslice_utest.c to cover additional branches of vTaskResume and xTaskGenericNotify.

Test Steps
-----------
cd FreeRTOS/Test/CMock
make coverage

Related Issue
-----------
TS-24219
TS-24208


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
