### PR TITLE
improve coverage for xTaskResumeAll.

### DIFF
--- a/FreeRTOS/Test/CMock/smp/global_vars.h
+++ b/FreeRTOS/Test/CMock/smp/global_vars.h
@@ -36,6 +36,12 @@
 /* Indicates that the task is actively running but scheduled to yield. */
 #define taskTASK_YIELDING       ( TaskRunning_t ) ( -2 )
 
+#if (configUSE_16_BIT_TICKS == 1)
+    #define taskEVENT_LIST_ITEM_VALUE_IN_USE 0x8000U
+#else
+    #define taskEVENT_LIST_ITEM_VALUE_IN_USE 0x80000000UL
+#endif
+
 typedef BaseType_t TaskRunning_t;
 
 typedef struct tskTaskControlBlock       /* The old naming convention is used to prevent breaking kernel aware debuggers. */

--- a/FreeRTOS/Test/CMock/smp/smp_utest_common.c
+++ b/FreeRTOS/Test/CMock/smp/smp_utest_common.c
@@ -201,9 +201,11 @@ unsigned int vFakePortGetCoreIDCallback( int cmock_num_calls )
     return ( unsigned int )xCurrentCoreId;
 }
 
-void vFakePortGetISRLock( void )
+void vFakePortGetISRLockCallback( int cmock_num_calls )
 {
     int i;
+    
+    ( void ) cmock_num_calls;
 
     /* Ensure that no other core is in the critical section. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
@@ -218,15 +220,19 @@ void vFakePortGetISRLock( void )
     xIsrLockCount[ xCurrentCoreId ]++;
 }
 
-void vFakePortReleaseISRLock( void )
+void vFakePortReleaseISRLockCallback( int cmock_num_calls )
 {
+    ( void ) cmock_num_calls;
+
     TEST_ASSERT_MESSAGE( xIsrLockCount[ xCurrentCoreId ] > 0, "xIsrLockCount[ xCurrentCoreId ] <= 0" );
     xIsrLockCount[ xCurrentCoreId ]--;
 }
 
-void vFakePortGetTaskLock( void )
+void vFakePortGetTaskLockCallback( int cmock_num_calls )
 {
     int i;
+
+    ( void ) cmock_num_calls;
 
     /* Ensure that no other core is in the critical section. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
@@ -241,8 +247,10 @@ void vFakePortGetTaskLock( void )
     xTaskLockCount[ xCurrentCoreId ]++;
 }
 
-void vFakePortReleaseTaskLock( void )
+void vFakePortReleaseTaskLockCallback( int cmock_num_calls )
 {
+    ( void ) cmock_num_calls;
+
     TEST_ASSERT_MESSAGE( xTaskLockCount[ xCurrentCoreId ] > 0, "xTaskLockCount[ xCurrentCoreId ] <= 0" );
     xTaskLockCount[ xCurrentCoreId ]--;
 
@@ -282,6 +290,11 @@ void commonSetUp( void )
 
     vFakePortGetCoreID_StubWithCallback( vFakePortGetCoreIDCallback );
 
+    vFakePortGetISRLock_StubWithCallback( vFakePortGetISRLockCallback );
+    vFakePortGetTaskLock_StubWithCallback( vFakePortGetTaskLockCallback );
+    vFakePortReleaseISRLock_StubWithCallback( vFakePortReleaseISRLockCallback );
+    vFakePortReleaseTaskLock_StubWithCallback( vFakePortReleaseTaskLockCallback );
+
     vFakeAssert_Ignore();
     vFakePortAssertIfISR_Ignore();
     vFakePortEnableInterrupts_Ignore();
@@ -289,8 +302,6 @@ void commonSetUp( void )
     ulFakePortSetInterruptMaskFromISR_IgnoreAndReturn( 0 );
     vFakePortClearInterruptMaskFromISR_Ignore();
 
-    vFakePortGetTaskLock_Ignore();
-    vFakePortGetISRLock_Ignore();
     vFakePortDisableInterrupts_IgnoreAndReturn(1);
     vFakePortRestoreInterrupts_Ignore();
     xTimerCreateTimerTask_IgnoreAndReturn(1);


### PR DESCRIPTION
improve coverage for xTaskResumeAll.

Description
-----------
Update covg_multiple_priorities_no_timeslice_utest.c to cover additional branches within xTaskResumeAll.

Test Steps
-----------
cd FreeRTOS/Test/CMock
make coverage

Related Issue
-----------
TS-24364


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
