### PR TITLE
Add xTaskIncrementTick coverage test cases

### DIFF
--- a/FreeRTOS/Test/CMock/smp/Makefile
+++ b/FreeRTOS/Test/CMock/smp/Makefile
@@ -8,6 +8,7 @@ include ../makefile.in
 SUITES	+=	single_priority_no_timeslice
 SUITES	+=	single_priority_timeslice
 SUITES	+=	multiple_priorities_no_timeslice
+SUITES	+=	multiple_priorities_timeslice
 # PROJECT and SUITE variables are determined based on path like so:
 #   $(UT_ROOT_DIR)/$(PROJECT)/$(SUITE)
 PROJECT :=  $(lastword $(subst /, ,$(dir $(abspath $(MAKEFILE_ABSPATH)))))

--- a/FreeRTOS/Test/CMock/smp/global_vars.h
+++ b/FreeRTOS/Test/CMock/smp/global_vars.h
@@ -30,6 +30,9 @@
 
 #include <stdbool.h>
 
+/* Indicates that the task is an Idle task. */
+#define taskATTRIBUTE_IS_IDLE    ( UBaseType_t ) ( 1UL << 0UL )
+
 /* Values that can be assigned to the ucNotifyState member of the TCB. */
 #define taskNOT_WAITING_NOTIFICATION              ( ( uint8_t ) 0 ) /* Must be zero as it is the initialised value. */
 #define taskWAITING_NOTIFICATION                  ( ( uint8_t ) 1 )

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/FreeRTOSConfig.h
@@ -1,0 +1,155 @@
+/*
+ * FreeRTOS V202112.00
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include "fake_assert.h"
+
+/*-----------------------------------------------------------
+* Application specific definitions.
+*
+* These definitions should be adjusted for your particular hardware and
+* application requirements.
+*
+* THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+* FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.  See
+* https://www.FreeRTOS.org/a00110.html
+*----------------------------------------------------------*/
+
+/* SMP test specific configuration */
+#define configRUN_MULTIPLE_PRIORITIES                    1
+#define configNUMBER_OF_CORES                            16
+#define configUSE_CORE_AFFINITY                          1
+#define configUSE_TIME_SLICING                           1
+#define configUSE_TASK_PREEMPTION_DISABLE                1
+#define configTICK_CORE                                  0
+
+/* OS Configuration */
+#define configUSE_PREEMPTION                             1
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION          0
+#define configUSE_IDLE_HOOK                              0
+#define configUSE_TICK_HOOK                              0
+#define configUSE_DAEMON_TASK_STARTUP_HOOK               1
+#define configTICK_RATE_HZ                               ( 1000 )
+#define configMINIMAL_STACK_SIZE                         ( ( unsigned short ) 70 )
+#define configTOTAL_HEAP_SIZE                            ( ( size_t ) ( 52 * 1024 ) )
+#define configMAX_TASK_NAME_LEN                          ( 12 )
+#define configUSE_TRACE_FACILITY                         1
+#define configUSE_16_BIT_TICKS                           0
+#define configIDLE_SHOULD_YIELD                          1
+#define configUSE_MUTEXES                                1
+#define configCHECK_FOR_STACK_OVERFLOW                   0
+#define configUSE_RECURSIVE_MUTEXES                      1
+#define configQUEUE_REGISTRY_SIZE                        20
+#define configUSE_MALLOC_FAILED_HOOK                     1
+#define configUSE_APPLICATION_TASK_TAG                   1
+#define configUSE_COUNTING_SEMAPHORES                    1
+#define configUSE_ALTERNATIVE_API                        0
+#define configUSE_QUEUE_SETS                             1
+#define configUSE_TASK_NOTIFICATIONS                     1
+#define configTASK_NOTIFICATION_ARRAY_ENTRIES            5
+#define configSUPPORT_STATIC_ALLOCATION                  1
+#define configSUPPORT_DYNAMIC_ALLOCATION                 1
+#define configINITIAL_TICK_COUNT                         ( ( TickType_t ) 0 )
+#define configSTREAM_BUFFER_TRIGGER_LEVEL_TEST_MARGIN    1
+#define portREMOVE_STATIC_QUALIFIER                      1
+#define portCRITICAL_NESTING_IN_TCB                      1
+#define portSTACK_GROWTH                                 ( 1 )
+#define configUSE_MINIMAL_IDLE_HOOK                      0
+
+/* Software timer related configuration options. */
+#define configUSE_TIMERS                                 1
+#define configTIMER_TASK_PRIORITY                        ( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH                         20
+#define configTIMER_TASK_STACK_DEPTH                     ( configMINIMAL_STACK_SIZE * 2 )
+
+#define configMAX_PRIORITIES                             ( 7 )
+
+/* Run time stats gathering configuration options. */
+unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
+void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that initialises the run time counter. */
+#define configGENERATE_RUN_TIME_STATS    0
+#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+#define portUSING_MPU_WRAPPERS                    0
+#define portHAS_STACK_OVERFLOW_CHECKING           0
+#define configENABLE_MPU                          0
+
+/* Co-routine related configuration options. */
+#define configUSE_CO_ROUTINES                     0
+#define configMAX_CO_ROUTINE_PRIORITIES           ( 2 )
+
+/* This demo makes use of one or more example stats formatting functions.  These
+ * format the raw data provided by the uxTaskGetSystemState() function in to human
+ * readable ASCII form.  See the notes in the implementation of vTaskList() within
+ * FreeRTOS/Source/tasks.c for limitations. */
+#define configUSE_STATS_FORMATTING_FUNCTIONS      1
+
+/* Set the following definitions to 1 to include the API function, or zero
+ * to exclude the API function.  In most cases the linker will remove unused
+ * functions anyway. */
+#define INCLUDE_vTaskPrioritySet                  1
+#define INCLUDE_uxTaskPriorityGet                 1
+#define INCLUDE_vTaskDelete                       1
+#define INCLUDE_vTaskCleanUpResources             0
+#define INCLUDE_vTaskSuspend                      1
+#define INCLUDE_vTaskDelayUntil                   1
+#define INCLUDE_vTaskDelay                        1
+#define INCLUDE_uxTaskGetStackHighWaterMark       1
+#define INCLUDE_xTaskGetSchedulerState            1
+#define INCLUDE_xTimerGetTimerDaemonTaskHandle    1
+#define INCLUDE_xTaskGetIdleTaskHandle            1
+#define INCLUDE_xTaskGetCurrentTaskHandle         1
+#define INCLUDE_xTaskGetHandle                    1
+#define INCLUDE_eTaskGetState                     1
+#define INCLUDE_xSemaphoreGetMutexHolder          1
+#define INCLUDE_xTimerPendFunctionCall            1
+#define INCLUDE_xTaskAbortDelay                   1
+#define INCLUDE_xTaskGetCurrentTaskHandle         1
+
+/* It is a good idea to define configASSERT() while developing.  configASSERT()
+ * uses the same semantics as the standard C assert() macro. */
+#define configASSERT( x )                             \
+    do                                                \
+    {                                                 \
+        if( x )                                       \
+        {                                             \
+            vFakeAssert( true, __FILE__, __LINE__ );  \
+        }                                             \
+        else                                          \
+        {                                             \
+            vFakeAssert( false, __FILE__, __LINE__ ); \
+        }                                             \
+    } while( 0 )
+
+#define configINCLUDE_MESSAGE_BUFFER_AMP_DEMO    0
+#if ( configINCLUDE_MESSAGE_BUFFER_AMP_DEMO == 1 )
+    extern void vGenerateCoreBInterrupt( void * xUpdatedMessageBuffer );
+    #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
+#endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
+
+#endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/Makefile
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/Makefile
@@ -1,0 +1,47 @@
+# indent with spaces
+.RECIPEPREFIX := $(.RECIPEPREFIX) $(.RECIPEPREFIX)
+
+# Do not move this line below the include
+MAKEFILE_ABSPATH    :=  $(abspath $(lastword $(MAKEFILE_LIST)))
+include ../../makefile.in
+
+# PROJECT_SRC lists the .c files under test
+PROJECT_SRC         :=  tasks.c
+
+# PROJECT_DEPS_SRC list the .c file that are dependencies of PROJECT_SRC files
+# Files in PROJECT_DEPS_SRC are excluded from coverage measurements
+PROJECT_DEPS_SRC    := list.c queue.c
+
+# PROJECT_HEADER_DEPS: headers that should be excluded from coverage measurements.
+PROJECT_HEADER_DEPS :=  FreeRTOS.h
+
+# SUITE_UT_SRC: .c files that contain test cases (must end in _utest.c)
+SUITE_UT_SRC        :=  multiple_priorities_timeslice_utest.c covg_multiple_priorities_timeslice_utest.c
+
+# SUITE_SUPPORT_SRC: .c files used for testing that do not contain test cases.
+# Paths are relative to PROJECT_DIR
+SUITE_SUPPORT_SRC   := smp_utest_common.c
+
+# List the headers used by PROJECT_SRC that you would like to mock
+MOCK_FILES_FP   +=  $(KERNEL_DIR)/include/timers.h
+MOCK_FILES_FP   +=  $(UT_ROOT_DIR)/config/fake_assert.h
+MOCK_FILES_FP   +=  $(UT_ROOT_DIR)/config/fake_port.h
+
+# List any addiitonal flags needed by the preprocessor
+CPPFLAGS            +=
+
+# List any addiitonal flags needed by the compiler
+CFLAGS              +=
+
+# Try not to edit beyond this line unless necessary.
+
+# Project is determined based on path: $(UT_ROOT_DIR)/$(PROJECT)
+PROJECT         :=  $(lastword $(subst /, ,$(dir $(abspath $(MAKEFILE_ABSPATH)/../))))
+SUITE           :=  $(lastword $(subst /, ,$(dir $(MAKEFILE_ABSPATH))))
+
+# Make variables available to included makefile
+export
+
+include ../../testdir.mk
+
+

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/covg_multiple_priorities_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/covg_multiple_priorities_timeslice_utest.c
@@ -1,0 +1,401 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+/*! @file covg_multiple_priority_timeslice_utest.c */
+
+/* C runtime includes. */
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Task includes */
+#include "FreeRTOS.h"
+#include "FreeRTOSConfig.h"
+#include "event_groups.h"
+#include "queue.h"
+
+/* Test includes. */
+#include "unity.h"
+#include "unity_memory.h"
+#include "../global_vars.h"
+#include "../smp_utest_common.h"
+
+/* Mock includes. */
+#include "mock_timers.h"
+#include "mock_fake_assert.h"
+#include "mock_fake_port.h"
+
+/* ===========================  EXTERN VARIABLES  =========================== */
+extern volatile UBaseType_t uxDeletedTasksWaitingCleanUp;
+extern volatile TCB_t * pxCurrentTCBs[ configNUMBER_OF_CORES ];
+extern UBaseType_t uxTopReadyPriority;
+extern List_t pxReadyTasksLists[ configMAX_PRIORITIES ];
+extern List_t xDelayedTaskList1;
+extern List_t * pxDelayedTaskList;
+extern UBaseType_t uxSchedulerSuspended;
+extern BaseType_t xTickCount;
+extern BaseType_t xNextTaskUnblockTime;
+extern BaseType_t xYieldPendings[ configNUMBER_OF_CORES ];
+
+/* ===========================  EXTERN FUNCTIONS  =========================== */
+extern void prvIdleTask( void );
+extern void prvMinimalIdleTask( void );
+extern BaseType_t xTaskIncrementTick( void );
+
+/* ============================  Unity Fixtures  ============================ */
+/*! called before each testcase */
+void setUp( void )
+{
+    commonSetUp();
+}
+
+/*! called after each testcase */
+void tearDown( void )
+{
+    commonTearDown();
+}
+
+/*! called at the beginning of the whole suite */
+void suiteSetUp()
+{
+}
+
+/*! called at the end of the whole suite */
+int suiteTearDown( int numFailures )
+{
+    return numFailures;
+}
+
+/* ==============================  Test Cases  ============================== */
+
+/**
+ * @brief xTaskIncrementTick - no equal priority task for time slice.
+ *
+ * No equal priority ready task when incrementing tick. Verify that the return value
+ * indicates switching is not required.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * for( x = ( ( UBaseType_t ) 0 ); x < ( ( UBaseType_t ) configNUMBER_OF_CORES ); x++ )
+ * {
+ *     if( listCURRENT_LIST_LENGTH( &( pxReadyTasksLists[ pxCurrentTCBs[ x ]->uxPriority ] ) ) > ( UBaseType_t ) 1 )
+ *     {
+ *         xYieldRequiredForCore[ x ] = pdTRUE;
+ *     }
+ *     else
+ *     {
+ *         mtCOVERAGE_TEST_MARKER();
+ *     }
+ * }
+ * @endcode
+ * ( listCURRENT_LIST_LENGTH( &( pxReadyTasksLists[ pxCurrentTCBs[ x ]->uxPriority ] ) ) > ( UBaseType_t ) 1 ) is false.
+ */
+void test_coverage_xTaskIncrementTick_no_eq_priority_task( void )
+{
+    BaseType_t xReturn;
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
+    TCB_t xTaskTCB = { NULL };
+    uint32_t i;
+
+    /* Setup the variables and structure. */
+    /* Initialize the idle priority ready list and set top ready priority to idle priority. */
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ] ) );
+    uxTopReadyPriority = tskIDLE_PRIORITY + 1;
+    uxSchedulerSuspended = pdFALSE;
+    xTickCount = 0;
+    xNextTaskUnblockTime = 0;
+    vListInitialise( &xDelayedTaskList1 );
+    pxDelayedTaskList = &xDelayedTaskList1;
+
+    /* Create idle tasks and add it into the ready list. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
+        xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+        pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].xTaskRunState = i;
+        xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
+        xTaskTCBs[ i ].uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+        listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
+    }
+
+    /* Create one more higher priority task to run on core 0. */
+    xTaskTCBs[ 0 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    xTaskTCB.uxPriority = tskIDLE_PRIORITY + 1;
+    xTaskTCB.xStateListItem.pvOwner = &xTaskTCB;
+    xTaskTCB.uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+    pxCurrentTCBs[ 0 ] = &xTaskTCB;
+    xTaskTCB.xTaskRunState = 0;
+    xTaskTCB.xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ];
+    xTaskTCB.uxTaskAttributes = 0;
+    listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ], &xTaskTCB.xStateListItem );
+
+    /* API calls. */
+    xReturn = xTaskIncrementTick();
+
+    /* Validations. */
+    /* Core 0 is running a higher priority task. No other task of equal priority is
+     * waiting to run. Switching is not required in this test. */
+    TEST_ASSERT_EQUAL( pdFALSE, xReturn );
+    TEST_ASSERT_EQUAL( portMAX_DELAY, xNextTaskUnblockTime );
+}
+
+/**
+ * @brief xTaskIncrementTick - current core has yield pending.
+ *
+ * No equal priority ready task when incrementing tick. However, the current core
+ * has yield pending. Verify that the return value indicates switching is required.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * if( ( xYieldRequiredForCore[ x ] != pdFALSE ) || ( xYieldPendings[ x ] != pdFALSE ) )
+ * {
+ *     if( x == ( UBaseType_t ) xCoreID )
+ *     {
+ *         xSwitchRequired = pdTRUE;
+ *     }
+ *     else
+ *     {
+ *         prvYieldCore( x );
+ *     }
+ * }
+ * @endcode
+ * ( xYieldRequiredForCore[ x ] != pdFALSE ) is false.
+ * ( xYieldPendings[ x ] != pdFALSE ) is true.
+ * ( x == ( UBaseType_t ) xCoreID ) is true.
+ */
+void test_coverage_xTaskIncrementTick_no_eq_priority_task_yield_pending( void )
+{
+    BaseType_t xReturn;
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
+    TCB_t xTaskTCB = { NULL };
+    uint32_t i;
+
+    /* Setup the variables and structure. */
+    /* Initialize the idle priority ready list and set top ready priority to idle priority. */
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ] ) );
+    uxTopReadyPriority = tskIDLE_PRIORITY + 1;
+    uxSchedulerSuspended = pdFALSE;
+    xTickCount = 0;
+    xNextTaskUnblockTime = 0;
+    vListInitialise( &xDelayedTaskList1 );
+    pxDelayedTaskList = &xDelayedTaskList1;
+
+    /* Create idle tasks and add it into the ready list. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
+        xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+        pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].xTaskRunState = i;
+        xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
+        xTaskTCBs[ i ].uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+        listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
+    }
+
+    /* Create one more higher priority task to run on core 0. */
+    xTaskTCBs[ 0 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    xTaskTCB.uxPriority = tskIDLE_PRIORITY + 1;
+    xTaskTCB.xStateListItem.pvOwner = &xTaskTCB;
+    xTaskTCB.uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+    pxCurrentTCBs[ 0 ] = &xTaskTCB;
+    xYieldPendings[ 0 ] = pdTRUE;
+    xTaskTCB.xTaskRunState = 0;
+    xTaskTCB.xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ];
+    xTaskTCB.uxTaskAttributes = 0;
+    listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ], &xTaskTCB.xStateListItem );
+
+    /* API calls. */
+    xReturn = xTaskIncrementTick();
+
+    /* Validations. */
+    /* Core 0 is running a higher priority task. No other task of equal priority is
+     * waiting to run. However, core 0 has yield pending. Switching is required for
+     * core 0. */
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+    TEST_ASSERT_EQUAL( portMAX_DELAY, xNextTaskUnblockTime );
+}
+
+/**
+ * @brief xTaskIncrementTick - task with preempetion disabled.
+ *
+ * The running task has preemption disabled. Verify the return value indicates switching
+ * is not required.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * for( x = ( UBaseType_t ) 0; x < ( UBaseType_t ) configNUMBER_OF_CORES; x++ )
+ * {
+ *     #if ( configUSE_TASK_PREEMPTION_DISABLE == 1 )
+ *         if( pxCurrentTCBs[ x ]->xPreemptionDisable == pdFALSE )
+ *     #endif
+ *     {
+ *         ....
+ *     }
+ *     ...
+ * }
+ * @endcode
+ * ( pxCurrentTCBs[ x ]->xPreemptionDisable == pdFALSE ) is false.
+ */
+void test_coverage_xTaskIncrementTick_preemption_disabled_task( void )
+{
+    BaseType_t xReturn;
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
+    TCB_t xTaskTCB = { NULL };
+    uint32_t i;
+
+    /* Setup the variables and structure. */
+    /* Initialize the idle priority ready list and set top ready priority to idle priority. */
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    uxTopReadyPriority = tskIDLE_PRIORITY;
+    uxSchedulerSuspended = pdFALSE;
+    xTickCount = 0;
+    xNextTaskUnblockTime = 0;
+    vListInitialise( &xDelayedTaskList1 );
+    pxDelayedTaskList = &xDelayedTaskList1;
+
+    /* Create idle tasks and add it into the ready list. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
+        xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+        pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].xTaskRunState = i;
+        xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
+        xTaskTCBs[ i ].uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+        listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
+    }
+
+    /* Create one more task with preemption disabled to run on core 0. */
+    xTaskTCBs[ 0 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    xTaskTCB.uxPriority = tskIDLE_PRIORITY;
+    xTaskTCB.xStateListItem.pvOwner = &xTaskTCB;
+    xTaskTCB.uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+    pxCurrentTCBs[ 0 ] = &xTaskTCB;
+    xTaskTCB.xTaskRunState = 0;
+    xTaskTCB.xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
+    xTaskTCB.uxTaskAttributes = 0;
+    xTaskTCB.xPreemptionDisable = pdTRUE;
+    listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCB.xStateListItem );
+
+    /* API calls. */
+    xReturn = xTaskIncrementTick();
+
+    /* Validations. */
+    /* Equal priority task is waiting to run. Preemption is disabled for task running
+     * on core 0. Switching is not required in this test. */
+    TEST_ASSERT_EQUAL( pdFALSE, xReturn );
+    TEST_ASSERT_EQUAL( portMAX_DELAY, xNextTaskUnblockTime );
+}
+
+/**
+ * @brief xTaskIncrementTick - ready higher priority delayed task.
+ *
+ * Verify that the core is yielding when ready a higher priority delayed ready task.
+ *
+ * <b>Coverage</b>
+ * @code{c}
+ * prvAddTaskToReadyList( pxTCB );
+ * ...
+ * #if ( configUSE_PREEMPTION == 1 )
+ * {
+ *     ...
+ *     #if ( configNUMBER_OF_CORES == 1 )
+ *     {
+ *         ...
+ *     }
+ *     #else
+ *     {
+ *         prvYieldForTask( pxTCB );
+ *     }
+ *     #endif
+ * }
+ * #endif
+ * @endcode
+ * prvYieldForTask( pxTCB ) is covered.
+ */
+void test_coverage_xTaskIncrementTick_ready_higher_priority_delayed_task( void )
+{
+    BaseType_t xReturn;
+    TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
+    TCB_t xTaskTCB = { NULL };
+    List_t xEventList = { 0 };
+    uint32_t i;
+
+    /* Setup the variables and structure. */
+    /* Initialize the idle priority ready list and set top ready priority to idle priority. */
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
+    vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ] ) );
+    vListInitialise( &xEventList );
+    uxTopReadyPriority = tskIDLE_PRIORITY;
+    uxSchedulerSuspended = pdFALSE;
+    xTickCount = 0;
+    xNextTaskUnblockTime = 0;
+    vListInitialise( &xDelayedTaskList1 );
+    pxDelayedTaskList = &xDelayedTaskList1;
+
+    /* Create idle tasks and add it into the ready list. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
+        xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+        pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
+        xTaskTCBs[ i ].xTaskRunState = i;
+        xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
+        xTaskTCBs[ i ].uxTaskAttributes = taskATTRIBUTE_IS_IDLE;
+        listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
+    }
+
+    /* Create one more higher priority task to run on core 0. */
+    xTaskTCB.uxPriority = tskIDLE_PRIORITY + 1;
+    xTaskTCB.xStateListItem.pvOwner = &xTaskTCB;
+    xTaskTCB.uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+    xTaskTCB.xTaskRunState = 0;
+    xTaskTCB.xStateListItem.pxContainer = pxDelayedTaskList;
+    xTaskTCB.uxTaskAttributes = 0;
+    xTaskTCB.xPreemptionDisable = pdTRUE;
+    listINSERT_END( pxDelayedTaskList, &xTaskTCB.xStateListItem );
+    xTaskTCB.xEventListItem.pvOwner = &xTaskTCB;
+    xTaskTCB.xEventListItem.pxContainer = &xEventList;
+    listINSERT_END( &xEventList, &xTaskTCB.xEventListItem );
+
+    /* API calls. */
+    xReturn = xTaskIncrementTick();
+
+    /* Validations. */
+    /* Core 0 is running a idle priority task. Switching is required in this test. */
+    TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+    /* The implementation will select the last core to yield for the higher priority
+     * task. Verify that the task running on the last core has state taskTASK_YIELDING. */
+    TEST_ASSERT_EQUAL( taskTASK_YIELDING, xTaskTCBs[ configNUMBER_OF_CORES - 1 ].xTaskRunState );
+    TEST_ASSERT_EQUAL( portMAX_DELAY, xNextTaskUnblockTime );
+}

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/multiple_priorities_timeslice_utest.c
@@ -1,0 +1,75 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2022 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+/*! @file multiple_priorities_timeslice_utest.c */
+
+/* C runtime includes. */
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Tasl includes */
+#include "FreeRTOS.h"
+#include "FreeRTOSConfig.h"
+#include "event_groups.h"
+#include "queue.h"
+
+/* Test includes. */
+#include "unity.h"
+#include "unity_memory.h"
+#include "../global_vars.h"
+#include "../smp_utest_common.h"
+
+/* Mock includes. */
+#include "mock_timers.h"
+#include "mock_fake_assert.h"
+#include "mock_fake_port.h"
+
+/* ============================  Unity Fixtures  ============================ */
+/*! called before each testcase */
+void setUp( void )
+{
+    commonSetUp();
+}
+
+/*! called after each testcase */
+void tearDown( void )
+{
+    commonTearDown();
+}
+
+/*! called at the beginning of the whole suite */
+void suiteSetUp()
+{
+}
+
+/*! called at the end of the whole suite */
+int suiteTearDown( int numFailures )
+{
+    return numFailures;
+}
+
+/* ==============================  Test Cases  ============================== */


### PR DESCRIPTION
Add xTaskIncrementTick coverage test cases

Description
-----------
* Add one test case in single core tasks_1_utest.c
* Add multiple_priority_timeslice test group for configUSE_TIME_SLICING and configUSE_TASK_PREEMPTION_DISABLE
* Add SMP xTaskIncrementTick coverage test cases.


Filename | -- | -- | Line Coverage | -- | Functions | -- | Branches | --
-- | -- | -- | -- | -- | -- | -- | -- | --
event_groups.c |   |   | 95.4 % | 167 / 175 | 100.0 % | 15 / 15 | 70.2 % | 66 / 94
list.c |   |   | 100.0 % | 40 / 40 | 100.0 % | 5 / 5 | 100.0 % | 6 / 6
queue.c |   |   | 95.3 % | 710 / 745 | 100.0 % | 46 / 46 | 97.0 % | 446 / 460
stream_buffer.c |   |   | 94.0 % | 300 / 319 | 100.0 % | 25 / 25 | 94.8 % | 182 / 192
tasks.c |   |   | 97.6 % | 1406 / 1440 | 100.0 % | 95 / 95 | 90.3 % | 919 / 1018
timers.c |   |   | 100.0 % | 237 / 237 | 100.0 % | 29 / 29 | 96.1 % | 74 / 77

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
