### PR TITLE
Fix uncrustify for smp unit test

### DIFF
--- a/FreeRTOS/Test/CMock/config/portmacro.h
+++ b/FreeRTOS/Test/CMock/config/portmacro.h
@@ -157,8 +157,8 @@ typedef unsigned long    UBaseType_t;
 #define portGET_CORE_ID()                vFakePortGetCoreID()
 #define portYIELD_CORE( x )              vFakePortYieldCore( x )
 
-#define portENTER_CRITICAL_FROM_ISR     vFakePortEnterCriticalFromISR
-#define portEXIT_CRITICAL_FROM_ISR      vFakePortExitCriticalFromISR
+#define portENTER_CRITICAL_FROM_ISR    vFakePortEnterCriticalFromISR
+#define portEXIT_CRITICAL_FROM_ISR     vFakePortExitCriticalFromISR
 
 #if ( configNUMBER_OF_CORES > 1 )
     #define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )

--- a/FreeRTOS/Test/CMock/queue/generic/queue_receive_blocking_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_receive_blocking_utest.c
@@ -75,7 +75,7 @@ int suiteTearDown( int numFailures )
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/queue/generic/queue_receive_nonblocking_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_receive_nonblocking_utest.c
@@ -79,7 +79,7 @@ int suiteTearDown( int numFailures )
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/queue/generic/queue_reset_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_reset_utest.c
@@ -72,7 +72,7 @@ int suiteTearDown( int numFailures )
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/queue/generic/queue_send_blocking_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_send_blocking_utest.c
@@ -50,7 +50,7 @@ static QueueHandle_t xQueueHandleStatic;
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/queue/generic/queue_send_nonblocking_utest.c
+++ b/FreeRTOS/Test/CMock/queue/generic/queue_send_nonblocking_utest.c
@@ -49,7 +49,7 @@
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/queue/semaphore/binary_semaphore_utest.c
+++ b/FreeRTOS/Test/CMock/queue/semaphore/binary_semaphore_utest.c
@@ -47,7 +47,7 @@ static SemaphoreHandle_t xSemaphoreHandleStatic;
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/queue/semaphore/counting_semaphore_utest.c
+++ b/FreeRTOS/Test/CMock/queue/semaphore/counting_semaphore_utest.c
@@ -45,7 +45,7 @@ static SemaphoreHandle_t xSemaphoreHandleStatic;
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/queue/semaphore/mutex_utest.c
+++ b/FreeRTOS/Test/CMock/queue/semaphore/mutex_utest.c
@@ -43,7 +43,7 @@ static SemaphoreHandle_t xSemaphoreHandleStatic = NULL;
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/queue/sets/queue_in_set_utest.c
+++ b/FreeRTOS/Test/CMock/queue/sets/queue_in_set_utest.c
@@ -77,7 +77,7 @@ int suiteTearDown( int numFailures )
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 

--- a/FreeRTOS/Test/CMock/smp/config_assert/local_portable.h
+++ b/FreeRTOS/Test/CMock/smp/config_assert/local_portable.h
@@ -12,4 +12,4 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
 StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
                                      TaskFunction_t pxCode,
                                      void * pvParameters );
-#endif
+#endif /* ifndef LOCAL_PORTABLE_H */

--- a/FreeRTOS/Test/CMock/smp/global_vars.h
+++ b/FreeRTOS/Test/CMock/smp/global_vars.h
@@ -31,32 +31,32 @@
 #include <stdbool.h>
 
 /* Indicates that the task is an Idle task. */
-#define taskATTRIBUTE_IS_IDLE    ( UBaseType_t ) ( 1UL << 0UL )
+#define taskATTRIBUTE_IS_IDLE                   ( UBaseType_t ) ( 1UL << 0UL )
 
 /*
  * Macros used by vListTask to indicate which state a task is in.
  */
-#define tskRUNNING_CHAR      ( 'X' )
-#define tskBLOCKED_CHAR      ( 'B' )
-#define tskREADY_CHAR        ( 'R' )
-#define tskDELETED_CHAR      ( 'D' )
-#define tskSUSPENDED_CHAR    ( 'S' )
+#define tskRUNNING_CHAR                         ( 'X' )
+#define tskBLOCKED_CHAR                         ( 'B' )
+#define tskREADY_CHAR                           ( 'R' )
+#define tskDELETED_CHAR                         ( 'D' )
+#define tskSUSPENDED_CHAR                       ( 'S' )
 
 /* Values that can be assigned to the ucNotifyState member of the TCB. */
-#define taskNOT_WAITING_NOTIFICATION              ( ( uint8_t ) 0 ) /* Must be zero as it is the initialised value. */
-#define taskWAITING_NOTIFICATION                  ( ( uint8_t ) 1 )
-#define taskNOTIFICATION_RECEIVED                 ( ( uint8_t ) 2 )
+#define taskNOT_WAITING_NOTIFICATION            ( ( uint8_t ) 0 )   /* Must be zero as it is the initialised value. */
+#define taskWAITING_NOTIFICATION                ( ( uint8_t ) 1 )
+#define taskNOTIFICATION_RECEIVED               ( ( uint8_t ) 2 )
 
 /* Indicates that the task is not actively running on any core. */
-#define taskTASK_NOT_RUNNING    ( TaskRunning_t ) ( -1 )
+#define taskTASK_NOT_RUNNING                    ( TaskRunning_t ) ( -1 )
 
 /* Indicates that the task is actively running but scheduled to yield. */
-#define taskTASK_YIELDING       ( TaskRunning_t ) ( -2 )
+#define taskTASK_YIELDING                       ( TaskRunning_t ) ( -2 )
 
-#if (configUSE_16_BIT_TICKS == 1)
-    #define taskEVENT_LIST_ITEM_VALUE_IN_USE 0x8000U
+#if ( configUSE_16_BIT_TICKS == 1 )
+    #define taskEVENT_LIST_ITEM_VALUE_IN_USE    0x8000U
 #else
-    #define taskEVENT_LIST_ITEM_VALUE_IN_USE 0x80000000UL
+    #define taskEVENT_LIST_ITEM_VALUE_IN_USE    0x80000000UL
 #endif
 
 typedef BaseType_t TaskRunning_t;

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_long_idle_name/local_portable.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_long_idle_name/local_portable.h
@@ -12,4 +12,4 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
 StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
                                      TaskFunction_t pxCode,
                                      void * pvParameters );
-#endif
+#endif /* ifndef LOCAL_PORTABLE_H */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/FreeRTOSConfig.h
@@ -43,7 +43,7 @@
 
 /* SMP test specific configuration */
 #define configRUN_MULTIPLE_PRIORITIES                    1
-#define configNUMBER_OF_CORES                                  16
+#define configNUMBER_OF_CORES                            16
 #define configUSE_CORE_AFFINITY                          1
 #define configUSE_TIME_SLICING                           0
 #define configUSE_TASK_PREEMPTION_DISABLE                1
@@ -94,8 +94,8 @@
 /* Run time stats gathering configuration options. */
 unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
 void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that initialises the run time counter. */
-#define configGENERATE_RUN_TIME_STATS    0
-#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+#define configGENERATE_RUN_TIME_STATS             0
+#define portGET_RUN_TIME_COUNTER_VALUE()    ulGetRunTimeCounterValue()
 #define portUSING_MPU_WRAPPERS                    0
 #define portHAS_STACK_OVERFLOW_CHECKING           0
 #define configENABLE_MPU                          0

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/covg_multiple_priorities_no_timeslice_utest.c
@@ -48,15 +48,15 @@
 #include "mock_fake_assert.h"
 #include "mock_fake_port.h"
 
-#define tskSTATICALLY_ALLOCATED_STACK_ONLY      ( ( uint8_t ) 1 )
-#define tskSTACK_FILL_BYTE                      ( 0xa5U )
-#define TEST_VTASKLIST_BUFFER_SIZE              ( 800 )     /* Size for task list. */
+#define tskSTATICALLY_ALLOCATED_STACK_ONLY    ( ( uint8_t ) 1 )
+#define tskSTACK_FILL_BYTE                    ( 0xa5U )
+#define TEST_VTASKLIST_BUFFER_SIZE            ( 800 )       /* Size for task list. */
 
 /* ===========================  EXTERN VARIABLES  =========================== */
 extern volatile UBaseType_t uxCurrentNumberOfTasks;
 extern volatile UBaseType_t uxDeletedTasksWaitingCleanUp;
 extern volatile UBaseType_t uxSchedulerSuspended;
-extern volatile TCB_t *  pxCurrentTCBs[ configNUMBER_OF_CORES ];
+extern volatile TCB_t * pxCurrentTCBs[ configNUMBER_OF_CORES ];
 extern volatile BaseType_t xSchedulerRunning;
 extern volatile TickType_t xTickCount;
 extern List_t pxReadyTasksLists[ configMAX_PRIORITIES ];
@@ -83,7 +83,7 @@ extern void prvCheckTasksWaitingTermination( void );
 extern void prvDeleteTCB( TCB_t * pxTCB );
 
 /* ==============================  Global VARIABLES ============================== */
-TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
 
 /* ============================  Unity Fixtures  ============================ */
 /*! called before each testcase */
@@ -93,9 +93,9 @@ void setUp( void )
 
     commonSetUp();
 
-    for( uxPriority = (UBaseType_t)0U; uxPriority < (UBaseType_t)configMAX_PRIORITIES; uxPriority++ )
+    for( uxPriority = ( UBaseType_t ) 0U; uxPriority < ( UBaseType_t ) configMAX_PRIORITIES; uxPriority++ )
     {
-        vListInitialise( &( pxReadyTasksLists[uxPriority] ) );
+        vListInitialise( &( pxReadyTasksLists[ uxPriority ] ) );
     }
 
     vListInitialise( &xSuspendedTaskList );
@@ -156,7 +156,7 @@ static void prvInitialiseTestStack( TCB_t * pxTCB,
     {
         pxTopOfStack = &( pxTCB->pxStack[ ulStackDepth - ( uint32_t ) 1 ] );
         pxTopOfStack = ( StackType_t * ) ( ( ( portPOINTER_SIZE_TYPE ) pxTopOfStack ) &
-                       ( ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK ) ) );
+                                           ( ~( ( portPOINTER_SIZE_TYPE ) portBYTE_ALIGNMENT_MASK ) ) );
 
         #if ( configRECORD_STACK_HIGH_ADDRESS == 1 )
         {
@@ -244,7 +244,7 @@ void test_coverage_vTaskPreemptionEnable_scheduler_running( void )
     xTaskTCB.xTaskRunState = -1; /* taskTASK_NOT_RUNNING. */
 
     xSchedulerRunning = pdTRUE;
-    
+
     /* Clear callback in commonSetUp. */
     vFakePortEnterCriticalSection_StubWithCallback( NULL );
     vFakePortExitCriticalSection_StubWithCallback( NULL );
@@ -276,7 +276,7 @@ void test_coverage_vTaskPreemptionEnable_null_handle( void )
     TCB_t xTaskTCB = { NULL };
     UBaseType_t uxInterruptMask = 0x12345678;
 
-    xTaskTCB.xPreemptionDisable  = pdTRUE;
+    xTaskTCB.xPreemptionDisable = pdTRUE;
     xTaskTCB.xTaskRunState = -1; /* taskTASK_NOT_RUNNING. */
     pxCurrentTCBs[ 0 ] = &xTaskTCB;
 
@@ -326,7 +326,7 @@ void test_coverage_vTaskPreemptionEnable_task_not_running_gt_cores( void )
     TCB_t xTaskTCB = { NULL };
 
     /* Setup variables. */
-    xTaskTCB.xPreemptionDisable  = pdTRUE;
+    xTaskTCB.xPreemptionDisable = pdTRUE;
     xTaskTCB.xTaskRunState = configNUMBER_OF_CORES;
 
     xSchedulerRunning = pdTRUE;
@@ -370,7 +370,7 @@ void test_coverage_vTaskPreemptionEnable_task_running( void )
     TCB_t xTaskTCB = { NULL };
 
     /* Setup variables. */
-    xTaskTCB.xPreemptionDisable  = pdTRUE;
+    xTaskTCB.xPreemptionDisable = pdTRUE;
     xTaskTCB.xTaskRunState = 0;
 
     xSchedulerRunning = pdTRUE;
@@ -416,7 +416,7 @@ void test_coverage_vTaskCoreAffinityGet( void )
     UBaseType_t uxCoreAffinityMask;
 
     /* Setup variables. */
-    xTaskTCB.uxCoreAffinityMask = 0x5555;   /* The value to be verified later. */
+    xTaskTCB.uxCoreAffinityMask = 0x5555; /* The value to be verified later. */
 
     /* Clear callback in commonSetUp. */
     vFakePortEnterCriticalSection_StubWithCallback( NULL );
@@ -456,8 +456,8 @@ void test_coverage_vTaskCoreAffinityGet_null_handle( void )
     UBaseType_t uxCoreAffinityMask;
 
     /* Setup variables. */
-    xTaskTCB.uxCoreAffinityMask = 0x5555;   /* The value to be verified later. */
-    pxCurrentTCBs[0] = &xTaskTCB;
+    xTaskTCB.uxCoreAffinityMask = 0x5555; /* The value to be verified later. */
+    pxCurrentTCBs[ 0 ] = &xTaskTCB;
 
     /* Clear callback in commonSetUp. */
     vFakePortEnterCriticalSection_StubWithCallback( NULL );
@@ -499,7 +499,7 @@ void test_coverage_uxTaskGetTaskNumber_task_handle( void )
     UBaseType_t uxTaskNumber = 0U;
 
     /* Setup the variables and structure. */
-    xTaskTCB.uxTaskNumber = 0x5a5a;         /* Value to be verified later. */
+    xTaskTCB.uxTaskNumber = 0x5a5a; /* Value to be verified later. */
 
     /* API call. */
     uxTaskNumber = uxTaskGetTaskNumber( &xTaskTCB );
@@ -791,7 +791,7 @@ void test_coverage_vTaskList_no_task_created( void )
     char pcWriteBuffer[ TEST_VTASKLIST_BUFFER_SIZE ] = "Test"; /* Validate the string is overwritten in the API call. */
 
     /* Setup the variables and structure. */
-    uxCurrentNumberOfTasks = 0;         /* No task is created. */
+    uxCurrentNumberOfTasks = 0; /* No task is created. */
 
     /* API calls. */
     vTaskList( pcWriteBuffer );
@@ -826,7 +826,7 @@ void test_coverage_vTaskList_task_eRunning( void )
     int xStringCompareResult;
     char pcGeneratedTaskName[ configMAX_TASK_NAME_LEN ];
     uint32_t i;
- 
+
     /* Setup the variables and structure. */
     xSchedulerRunning = pdTRUE;
 
@@ -843,10 +843,10 @@ void test_coverage_vTaskList_task_eRunning( void )
     listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCB.xStateListItem );
     prvInitialiseTestStack( &xTaskTCB, configMINIMAL_STACK_SIZE );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
-    
+
     /* API calls. */
     vTaskList( pcWriteBuffer );
-    
+
     /* Clean up malloc for stack. */
     vPortFreeStack( xTaskTCB.pxStack );
 
@@ -858,11 +858,12 @@ void test_coverage_vTaskList_task_eRunning( void )
     {
         pcGeneratedTaskName[ i ] = ' ';
     }
+
     pcGeneratedTaskName[ i ] = '\0';
 
     sprintf( pcExpectedResult, "%s\t%c\t%u\t%u\t%u\r\n", pcGeneratedTaskName, tskRUNNING_CHAR,
-        ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
-        ( unsigned int ) xTaskTCB.uxTaskNumber );
+             ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
+             ( unsigned int ) xTaskTCB.uxTaskNumber );
     xStringCompareResult = strcmp( pcExpectedResult, pcWriteBuffer );
     TEST_ASSERT_EQUAL( 0, xStringCompareResult );
 }
@@ -891,7 +892,7 @@ void test_coverage_vTaskList_task_eReady( void )
     int xStringCompareResult;
     char pcGeneratedTaskName[ configMAX_TASK_NAME_LEN ];
     uint32_t i;
- 
+
     /* Setup the variables and structure. */
     xSchedulerRunning = pdTRUE;
 
@@ -908,10 +909,10 @@ void test_coverage_vTaskList_task_eReady( void )
     listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCB.xStateListItem );
     prvInitialiseTestStack( &xTaskTCB, configMINIMAL_STACK_SIZE );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
-    
+
     /* API calls. */
     vTaskList( pcWriteBuffer );
-    
+
     /* Clean up malloc for stack. */
     vPortFreeStack( xTaskTCB.pxStack );
 
@@ -923,11 +924,12 @@ void test_coverage_vTaskList_task_eReady( void )
     {
         pcGeneratedTaskName[ i ] = ' ';
     }
+
     pcGeneratedTaskName[ i ] = '\0';
 
     sprintf( pcExpectedResult, "%s\t%c\t%u\t%u\t%u\r\n", pcGeneratedTaskName, tskREADY_CHAR,
-        ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
-        ( unsigned int ) xTaskTCB.uxTaskNumber );
+             ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
+             ( unsigned int ) xTaskTCB.uxTaskNumber );
     xStringCompareResult = strcmp( pcExpectedResult, pcWriteBuffer );
     TEST_ASSERT_EQUAL( 0, xStringCompareResult );
 }
@@ -956,7 +958,7 @@ void test_coverage_vTaskList_task_eBlocked( void )
     int xStringCompareResult;
     char pcGeneratedTaskName[ configMAX_TASK_NAME_LEN ];
     uint32_t i;
- 
+
     /* Setup the variables and structure. */
     xSchedulerRunning = pdTRUE;
 
@@ -973,10 +975,10 @@ void test_coverage_vTaskList_task_eBlocked( void )
     listINSERT_END( pxDelayedTaskList, &xTaskTCB.xStateListItem );
     prvInitialiseTestStack( &xTaskTCB, configMINIMAL_STACK_SIZE );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
-    
+
     /* API calls. */
     vTaskList( pcWriteBuffer );
-    
+
     /* Clean up malloc for stack. */
     vPortFreeStack( xTaskTCB.pxStack );
 
@@ -988,11 +990,12 @@ void test_coverage_vTaskList_task_eBlocked( void )
     {
         pcGeneratedTaskName[ i ] = ' ';
     }
+
     pcGeneratedTaskName[ i ] = '\0';
 
     sprintf( pcExpectedResult, "%s\t%c\t%u\t%u\t%u\r\n", pcGeneratedTaskName, tskBLOCKED_CHAR,
-        ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
-        ( unsigned int ) xTaskTCB.uxTaskNumber );
+             ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
+             ( unsigned int ) xTaskTCB.uxTaskNumber );
     xStringCompareResult = strcmp( pcExpectedResult, pcWriteBuffer );
     TEST_ASSERT_EQUAL( 0, xStringCompareResult );
 }
@@ -1021,7 +1024,7 @@ void test_coverage_vTaskList_task_eSuspended( void )
     int xStringCompareResult;
     char pcGeneratedTaskName[ configMAX_TASK_NAME_LEN ];
     uint32_t i;
- 
+
     /* Setup the variables and structure. */
     xSchedulerRunning = pdTRUE;
 
@@ -1038,10 +1041,10 @@ void test_coverage_vTaskList_task_eSuspended( void )
     listINSERT_END( &xSuspendedTaskList, &xTaskTCB.xStateListItem );
     prvInitialiseTestStack( &xTaskTCB, configMINIMAL_STACK_SIZE );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
-    
+
     /* API calls. */
     vTaskList( pcWriteBuffer );
-    
+
     /* Clean up malloc for stack. */
     vPortFreeStack( xTaskTCB.pxStack );
 
@@ -1053,11 +1056,12 @@ void test_coverage_vTaskList_task_eSuspended( void )
     {
         pcGeneratedTaskName[ i ] = ' ';
     }
+
     pcGeneratedTaskName[ i ] = '\0';
 
     sprintf( pcExpectedResult, "%s\t%c\t%u\t%u\t%u\r\n", pcGeneratedTaskName, tskSUSPENDED_CHAR,
-        ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
-        ( unsigned int ) xTaskTCB.uxTaskNumber );
+             ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
+             ( unsigned int ) xTaskTCB.uxTaskNumber );
     xStringCompareResult = strcmp( pcExpectedResult, pcWriteBuffer );
     TEST_ASSERT_EQUAL( 0, xStringCompareResult );
 }
@@ -1086,7 +1090,7 @@ void test_coverage_vTaskList_task_eDeleted( void )
     int xStringCompareResult;
     char pcGeneratedTaskName[ configMAX_TASK_NAME_LEN ];
     uint32_t i;
- 
+
     /* Setup the variables and structure. */
     xSchedulerRunning = pdTRUE;
 
@@ -1103,10 +1107,10 @@ void test_coverage_vTaskList_task_eDeleted( void )
     listINSERT_END( &xTasksWaitingTermination, &xTaskTCB.xStateListItem );
     prvInitialiseTestStack( &xTaskTCB, configMINIMAL_STACK_SIZE );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
-    
+
     /* API calls. */
     vTaskList( pcWriteBuffer );
-    
+
     /* Clean up malloc for stack. */
     vPortFreeStack( xTaskTCB.pxStack );
 
@@ -1118,11 +1122,12 @@ void test_coverage_vTaskList_task_eDeleted( void )
     {
         pcGeneratedTaskName[ i ] = ' ';
     }
+
     pcGeneratedTaskName[ i ] = '\0';
 
     sprintf( pcExpectedResult, "%s\t%c\t%u\t%u\t%u\r\n", pcGeneratedTaskName, tskDELETED_CHAR,
-        ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
-        ( unsigned int ) xTaskTCB.uxTaskNumber );
+             ( unsigned int ) xTaskTCB.uxPriority, ( unsigned int ) ( configMINIMAL_STACK_SIZE - 1U ),
+             ( unsigned int ) xTaskTCB.uxTaskNumber );
     xStringCompareResult = strcmp( pcExpectedResult, pcWriteBuffer );
     TEST_ASSERT_EQUAL( 0, xStringCompareResult );
 }
@@ -1155,9 +1160,11 @@ void test_coverage_xTaskDelayUntil_current_task_should_delay( void )
     BaseType_t xShouldDelay;
 
     /* Setup the variables and structure. */
+
     /* ( PrevousWakeTime + 10 ) is greater than xTickCount. The return value should
      * indicate that the task is actual delayed. */
     xTickCount = 15;
+
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
         xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
@@ -1172,7 +1179,7 @@ void test_coverage_xTaskDelayUntil_current_task_should_delay( void )
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
         uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
     }
-    
+
     /* Expectations. */
     vFakePortYield_StubWithCallback( NULL );
     vFakePortYield_Expect();
@@ -1216,6 +1223,7 @@ void test_coverage_prvAddNewTaskToReadyList_create_more_idle_tasks_than_cores( v
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
         xTaskTCBs[ i ].uxTaskAttributes = -1;
+
         if( i < configNUMBER_OF_CORES )
         {
             /* Create idle tasks with equal number of cores. */
@@ -1277,11 +1285,11 @@ void test_coverage_vTaskCoreAffinitySet_null_task_handle( void )
 
     /* Setup the variables and structure. */
     uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
-    vCreateStaticTestTask( &xTaskTCB,
-                           uxCoreAffinityMask,
-                           tskIDLE_PRIORITY,
-                           0,
-                           pdFALSE );
+    vCreateStaticTestTaskAffinity( &xTaskTCB,
+                                   uxCoreAffinityMask,
+                                   tskIDLE_PRIORITY,
+                                   0,
+                                   pdFALSE );
     pxCurrentTCBs[ 0 ] = &xTaskTCB;
     xSchedulerRunning = pdTRUE;
 
@@ -1336,11 +1344,11 @@ void test_coverage_vTaskCoreAffinitySet_task_not_running_no_new_core( void )
     /* Setup the variables and structure. */
     /* This task is allowed to run on core 0 and core 1 only. */
     uxCoreAffinityMask = ( 1U << 0 ) | ( 1U << 1 );
-    vCreateStaticTestTask( &xTaskTCB,
-                           uxCoreAffinityMask,
-                           tskIDLE_PRIORITY,
-                           configNUMBER_OF_CORES,
-                           pdFALSE );
+    vCreateStaticTestTaskAffinity( &xTaskTCB,
+                                   uxCoreAffinityMask,
+                                   tskIDLE_PRIORITY,
+                                   configNUMBER_OF_CORES,
+                                   pdFALSE );
     xSchedulerRunning = pdTRUE;
 
     /* Expectations. */
@@ -1387,6 +1395,7 @@ void test_coverage_prvYieldForTask_task_is_running_eq( void )
         xYieldPendings[ i ] = pdFALSE;
         pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
     }
+
     /* Set one of the running xTaskRunState equals to configNUMBER_OF_CORES. */
     xTaskTCBs[ 0 ].xTaskRunState = configNUMBER_OF_CORES;
 
@@ -1399,6 +1408,7 @@ void test_coverage_prvYieldForTask_task_is_running_eq( void )
     /* Validation. */
     /* Core 0 will not be requested to yield. */
     TEST_ASSERT( xTaskTCBs[ 0 ].xTaskRunState != taskTASK_YIELDING );
+
     /* No core will be requested to yield. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
@@ -1433,6 +1443,7 @@ void test_coverage_prvYieldForTask_task_yielding( void )
         xYieldPendings[ i ] = pdFALSE;
         pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
     }
+
     /* Set xTaskRunState of the running task to taskTASK_YIELDING. */
     xTaskTCBs[ 0 ].xTaskRunState = taskTASK_YIELDING;
 
@@ -1445,6 +1456,7 @@ void test_coverage_prvYieldForTask_task_yielding( void )
     /* Validation. */
     /* Core 0 remains of state taskTASK_YIELDING. */
     TEST_ASSERT( xTaskTCBs[ 0 ].xTaskRunState == taskTASK_YIELDING );
+
     /* No core will be requested to yield. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
@@ -1479,6 +1491,7 @@ void test_coverage_prvYieldForTask_task_yield_pending( void )
         xYieldPendings[ i ] = pdFALSE;
         pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
     }
+
     /* Set one of the running core with yield pending. */
     xYieldPendings[ 0 ] = pdTRUE;
 
@@ -1491,6 +1504,7 @@ void test_coverage_prvYieldForTask_task_yield_pending( void )
     /* Validation. */
     /* Core 0 remains yield pending. */
     TEST_ASSERT( xYieldPendings[ 0 ] == pdTRUE );
+
     /* Other core will not be requested to yield. */
     for( i = 1; i < configNUMBER_OF_CORES; i++ )
     {
@@ -1527,6 +1541,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_preemption_disabled( vo
     uint32_t i = 0;
 
     /* Setup the variables and structure. */
+
     /* Initialize the idle priority ready list and set top ready priority to higher
      * priority than idle. */
     vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
@@ -1537,22 +1552,22 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_preemption_disabled( vo
     /* Create core numbers running idle task. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                              ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                              tskIDLE_PRIORITY,
-                              i,
-                              pdTRUE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY,
+                                       i,
+                                       pdTRUE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
     }
 
     /* Create two higher priority normal task. */
     for( i = configNUMBER_OF_CORES; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY + 1,
-                               taskTASK_NOT_RUNNING,
-                               pdFALSE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY + 1,
+                                       taskTASK_NOT_RUNNING,
+                                       pdFALSE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ], &xTaskTCBs[ i ].xStateListItem );
     }
 
@@ -1579,6 +1594,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_preemption_disabled( vo
     prvSelectHighestPriorityTask( 0 );
 
     /* Validations.*/
+
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. Task on core 1 is yielding. */
     TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
@@ -1618,6 +1634,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_preemption_enabled( voi
     uint32_t i = 0;
 
     /* Setup the variables and structure. */
+
     /* Initialize the idle priority ready list and set top ready priority to higher
      * priority than idle. */
     vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
@@ -1628,22 +1645,22 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_preemption_enabled( voi
     /* Create core numbers running idle task. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                              ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                              tskIDLE_PRIORITY,
-                              i,
-                              pdTRUE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY,
+                                       i,
+                                       pdTRUE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
     }
 
     /* Create two higher priority normal task. */
     for( i = configNUMBER_OF_CORES; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY + 1,
-                               taskTASK_NOT_RUNNING,
-                               pdFALSE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY + 1,
+                                       taskTASK_NOT_RUNNING,
+                                       pdFALSE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ], &xTaskTCBs[ i ].xStateListItem );
     }
 
@@ -1674,6 +1691,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_preemption_enabled( voi
     prvSelectHighestPriorityTask( 0 );
 
     /* Validations.*/
+
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. Task on core 1 is yielding. */
     TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
@@ -1684,7 +1702,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_preemption_enabled( voi
 /**
  * @brief xTaskRemoveFromEventList - Remove a equal priority task from event list.
  *
- * The task is removed from event list. Verified this task is put back to ready list 
+ * The task is removed from event list. Verified this task is put back to ready list
  * and removed from event list. Current core is not requested to yield.
  *
  * <b>Coverage</b>
@@ -1755,10 +1773,10 @@ void test_coverage_xTaskRemoveFromEventList_remove_eq_priority_task( void )
 
     /* Expectations. */
     vFakePortGetCoreID_StubWithCallback( NULL );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get prvYieldCore. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get xYieldPendings. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get prvYieldCore. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get xYieldPendings. */
 
     /* API call. */
     xReturn = xTaskRemoveFromEventList( &xEventList );
@@ -1823,6 +1841,7 @@ void test_coverage_xTaskRemoveFromEventList_remove_higher_priority_task( void )
         xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+
         if( i == 0 )
         {
             /* Core 0 is running an idle task in order to be requested to yield. */
@@ -1856,9 +1875,9 @@ void test_coverage_xTaskRemoveFromEventList_remove_higher_priority_task( void )
 
     /* Expectations. */
     vFakePortGetCoreID_StubWithCallback( NULL );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get prvYieldCore. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get xYieldPendings. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get prvYieldCore. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get xYieldPendings. */
 
     /* API call. */
     xReturn = xTaskRemoveFromEventList( &xEventList );
@@ -1920,6 +1939,7 @@ void test_coverage_vTaskRemoveFromUnorderedEventList_remove_higher_priority_task
         xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+
         if( i == 0 )
         {
             /* Core 0 is running an idle task in order to be requested to yield. */
@@ -1953,8 +1973,8 @@ void test_coverage_vTaskRemoveFromUnorderedEventList_remove_higher_priority_task
 
     /* Expectations. */
     vFakePortGetCoreID_StubWithCallback( NULL );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get prvYieldCore. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get prvYieldCore. */
 
     /* API call. */
     vTaskRemoveFromUnorderedEventList( &xTaskTCB.xEventListItem, 500 | 0x80000000UL );
@@ -2000,9 +2020,9 @@ void test_coverage_vTaskEnterCritical_task_in_critical_already( void )
 
     /* Expectations. */
     vFakePortDisableInterrupts_ExpectAndReturn( 0 );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Get both locks. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Increment the critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Check first time enter critical section. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get both locks. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Increment the critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check first time enter critical section. */
 
     /* API call. */
     vTaskEnterCritical();
@@ -2040,9 +2060,9 @@ void test_coverage_vTaskEnterCriticalFromISR_isr_in_critical_already( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    ulFakePortSetInterruptMaskFromISR_ExpectAndReturn( 0x5a5a );    /* The value to be verified. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Get ISR locks. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Increment the critical nesting count. */
+    ulFakePortSetInterruptMaskFromISR_ExpectAndReturn( 0x5a5a ); /* The value to be verified. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );                     /* Get ISR locks. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 );                     /* Increment the critical nesting count. */
 
     /* API call. */
     uxSavedInterruptStatus = vTaskEnterCriticalFromISR();
@@ -2083,10 +2103,10 @@ void test_coverage_vTaskExitCritical_task_enter_critical_mt_1( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* configASSERT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Check critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Decrease the critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Check exit critical section. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* configASSERT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Decrease the critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check exit critical section. */
 
     /* API call. */
     vTaskExitCritical();
@@ -2124,13 +2144,14 @@ void test_coverage_vTaskExitCritical_task_not_in_critical( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* configASSERT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Check critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* configASSERT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
 
     /* API call. */
     vTaskExitCritical();
 
     /* Validation. */
+
     /* Critical section count won't be updated. This test shows it's result in the
      * coverage report. */
 }
@@ -2181,10 +2202,10 @@ void test_coverage_vTaskExitCriticalFromISR_isr_enter_critical_mt_1( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* configASSERT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Check critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Decrement critical nesting count. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Check critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* configASSERT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Decrement critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
 
     /* API call. */
     /* The mask value has not effect since ISR enters critical section more than 1 time. */
@@ -2224,14 +2245,15 @@ void test_coverage_vTaskExitCriticalFromISR_isr_not_in_critical( void )
     vFakePortGetCoreID_StubWithCallback( NULL );
 
     /* Expectations. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* configASSERT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );        /* Check critical nesting count. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* configASSERT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Check critical nesting count. */
 
     /* API call. */
     /* The mask value has not effect since ISR is not in critlcal section. */
     vTaskExitCriticalFromISR( 0x5a5a );
 
     /* Validation. */
+
     /* Critical section count won't be changed. This test shows it's result in the
      * coverage report. */
 }
@@ -2240,29 +2262,28 @@ void test_coverage_vTaskExitCriticalFromISR_isr_not_in_critical( void )
  * @brief  pvTaskGetThreadLocalStoragePointer - xIndex is zero.
  *
  * Cover the situation that xIndex is zero and less than configNUM_THREAD_LOCAL_STORAGE_POINTERS when pvTaskGetThreadLocalStoragePointer
- * is called. 
- * 
+ * is called.
+ *
  * <b>Coverage</b>
  * @code{c}
  *     if( ( xIndex >= 0 ) &&
-            ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
-        {
-            pxTCB = prvGetTCBFromHandle( xTaskToQuery );
-            pvReturn = pxTCB->pvThreadLocalStoragePointers[ xIndex ];
-        }
+ *          ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
+ *      {
+ *          pxTCB = prvGetTCBFromHandle( xTaskToQuery );
+ *          pvReturn = pxTCB->pvThreadLocalStoragePointers[ xIndex ];
+ *      }
  * @endcode
  * ( ( xIndex >= 0 ) && ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) ) is true.
  */
 void test_coverage_pvTaskGetThreadLocalStoragePointer_xIndex_is_zero( void )
 {
-    
     uint32_t i = 454545;
     void * pValue = &i;
     void * ret_pValue;
     TCB_t tcb;
     TaskHandle_t task_handle = &tcb;
 
-     /* Setup */
+    /* Setup */
     /* API Call */
     vTaskSetThreadLocalStoragePointer( task_handle,
                                        0,
@@ -2271,20 +2292,21 @@ void test_coverage_pvTaskGetThreadLocalStoragePointer_xIndex_is_zero( void )
     /* Validations */
     TEST_ASSERT_EQUAL_PTR( pValue, ret_pValue );
 }
+
 /**
  * @brief  pvTaskGetThreadLocalStoragePointer - taskhandle is NULL.
  *
  * Cover the situation that xIndex is zero and handle is NULL when pvTaskGetThreadLocalStoragePointer
- * is called. 
- * 
+ * is called.
+ *
  * <b>Coverage</b>
  * @code{c}
  *     if( ( xIndex >= 0 ) &&
-            ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
-        {
-            pxTCB = prvGetTCBFromHandle( xTaskToQuery );
-            pvReturn = pxTCB->pvThreadLocalStoragePointers[ xIndex ];
-        }
+ *          ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
+ *      {
+ *          pxTCB = prvGetTCBFromHandle( xTaskToQuery );
+ *          pvReturn = pxTCB->pvThreadLocalStoragePointers[ xIndex ];
+ *      }
  * @endcode
  * ( ( xIndex >= 0 ) && ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) ) is true.
  */
@@ -2294,7 +2316,7 @@ void test_coverage_pvTaskGetThreadLocalStoragePointer_null_handle( void )
     uint32_t i = 454545;
     void * pValue = &i;
     void * ret_pValue;
-    
+
     /* Setup */
     /* Create a task as current running task on core 0. */
     pxCurrentTCBs[ 0 ] = &xTaskTCB;
@@ -2308,24 +2330,25 @@ void test_coverage_pvTaskGetThreadLocalStoragePointer_null_handle( void )
     /* Validations */
     TEST_ASSERT_EQUAL_PTR( pValue, ret_pValue );
 }
+
 /**
  * @brief  pvTaskGetThreadLocalStoragePointer - xIndex is greater than configNUM_THREAD_LOCAL_STORAGE_POINTERS .
  *
  * Cover the situation that xIndex is greater than configNUM_THREAD_LOCAL_STORAGE_POINTERS when pvTaskGetThreadLocalStoragePointer
- * is called. 
- * 
+ * is called.
+ *
  * <b>Coverage</b>
  * @code{c}
  *     if( ( xIndex >= 0 ) &&
-            ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
-        {
-            pxTCB = prvGetTCBFromHandle( xTaskToQuery );
-            pvReturn = pxTCB->pvThreadLocalStoragePointers[ xIndex ];
-        }
-        else
-        {
-            pvReturn = NULL;
-        }
+ *          ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) )
+ *      {
+ *          pxTCB = prvGetTCBFromHandle( xTaskToQuery );
+ *          pvReturn = pxTCB->pvThreadLocalStoragePointers[ xIndex ];
+ *      }
+ *      else
+ *      {
+ *          pvReturn = NULL;
+ *      }
  * @endcode
  * ( ( xIndex >= 0 ) && ( xIndex < configNUM_THREAD_LOCAL_STORAGE_POINTERS ) ) is false.
  */
@@ -2365,11 +2388,11 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_le( void )
 {
     TCB_t xTaskTCB = { NULL };
     TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
-    UBaseType_t uxIndexToNotify = 0;    /* Use index 0 in this test. */
+    UBaseType_t uxIndexToNotify = 0; /* Use index 0 in this test. */
     uint32_t ulPreviousNotificationValue;
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
     BaseType_t xReturn;
-    BaseType_t xSavedInterruptMask = 0x1234;   /* Interrupt mask to be verified. */
+    BaseType_t xSavedInterruptMask = 0x1234; /* Interrupt mask to be verified. */
     List_t xEventList = { 0 };
     uint32_t i;
 
@@ -2418,14 +2441,14 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_le( void )
     /* Expectations. */
     vFakePortAssertIfInterruptPriorityInvalid_Expect();
     vFakePortEnterCriticalFromISR_ExpectAndReturn( xSavedInterruptMask );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get prvYieldCore. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get prvYieldCore. */
     vFakePortExitCriticalFromISR_Expect( xSavedInterruptMask );
 
     /* API call. */
     xReturn = xTaskGenericNotifyFromISR( &xTaskTCB,
                                          uxIndexToNotify,
-                                         0,       /* Value is not used with eNoAction. */
+                                         0, /* Value is not used with eNoAction. */
                                          eNoAction,
                                          &ulPreviousNotificationValue,
                                          &xHigherPriorityTaskWoken );
@@ -2464,11 +2487,11 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_gt( void )
 {
     TCB_t xTaskTCB = { NULL };
     TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
-    UBaseType_t uxIndexToNotify = 0;    /* Use index 0 in this test. */
+    UBaseType_t uxIndexToNotify = 0; /* Use index 0 in this test. */
     uint32_t ulPreviousNotificationValue;
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
     BaseType_t xReturn;
-    BaseType_t xSavedInterruptMask = 0x1234;   /* Interrupt mask to be verified. */
+    BaseType_t xSavedInterruptMask = 0x1234; /* Interrupt mask to be verified. */
     List_t xEventList = { 0 };
     uint32_t i;
 
@@ -2485,6 +2508,7 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_gt( void )
         xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+
         if( i == 0 )
         {
             /* Core 0 is running an idle task in order to be requested to yield. */
@@ -2534,7 +2558,7 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_gt( void )
     /* API call. */
     xReturn = xTaskGenericNotifyFromISR( &xTaskTCB,
                                          uxIndexToNotify,
-                                         0,       /* Value is not used with eNoAction. */
+                                         0, /* Value is not used with eNoAction. */
                                          eNoAction,
                                          &ulPreviousNotificationValue,
                                          &xHigherPriorityTaskWoken );
@@ -2574,10 +2598,10 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_gt_null_param( void )
 {
     TCB_t xTaskTCB = { NULL };
     TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
-    UBaseType_t uxIndexToNotify = 0;    /* Use index 0 in this test. */
+    UBaseType_t uxIndexToNotify = 0; /* Use index 0 in this test. */
     uint32_t ulPreviousNotificationValue;
     BaseType_t xReturn;
-    BaseType_t xSavedInterruptMask = 0x1234;   /* Interrupt mask to be verified. */
+    BaseType_t xSavedInterruptMask = 0x1234; /* Interrupt mask to be verified. */
     List_t xEventList = { 0 };
     uint32_t i;
 
@@ -2594,6 +2618,7 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_gt_null_param( void )
         xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+
         if( i == 0 )
         {
             /* Core 0 is running an idle task in order to be requested to yield. */
@@ -2643,7 +2668,7 @@ void test_coverage_xTaskGenericNotifyFromISR_priority_gt_null_param( void )
     /* API call. */
     xReturn = xTaskGenericNotifyFromISR( &xTaskTCB,
                                          uxIndexToNotify,
-                                         0,       /* Value is not used with eNoAction. */
+                                         0, /* Value is not used with eNoAction. */
                                          eNoAction,
                                          &ulPreviousNotificationValue,
                                          NULL );
@@ -2681,9 +2706,9 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_le( void )
 {
     TCB_t xTaskTCB = { NULL };
     TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
-    UBaseType_t uxIndexToNotify = 0;    /* Use index 0 in this test. */
+    UBaseType_t uxIndexToNotify = 0;         /* Use index 0 in this test. */
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-    BaseType_t xSavedInterruptMask = 0x1234;   /* Interrupt mask to be verified. */
+    BaseType_t xSavedInterruptMask = 0x1234; /* Interrupt mask to be verified. */
     List_t xEventList = { 0 };
     uint32_t i;
 
@@ -2732,8 +2757,8 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_le( void )
     /* Expectations. */
     vFakePortAssertIfInterruptPriorityInvalid_Expect();
     vFakePortEnterCriticalFromISR_ExpectAndReturn( xSavedInterruptMask );
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get portGET_CRITICAL_NESTING_COUNT. */
-    vFakePortGetCoreID_ExpectAndReturn( 0 );    /* Get prvYieldCore. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get portGET_CRITICAL_NESTING_COUNT. */
+    vFakePortGetCoreID_ExpectAndReturn( 0 ); /* Get prvYieldCore. */
     vFakePortExitCriticalFromISR_Expect( xSavedInterruptMask );
 
     /* API call. */
@@ -2774,9 +2799,9 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_gt( void )
 {
     TCB_t xTaskTCB = { NULL };
     TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
-    UBaseType_t uxIndexToNotify = 0;    /* Use index 0 in this test. */
+    UBaseType_t uxIndexToNotify = 0;         /* Use index 0 in this test. */
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-    BaseType_t xSavedInterruptMask = 0x1234;   /* Interrupt mask to be verified. */
+    BaseType_t xSavedInterruptMask = 0x1234; /* Interrupt mask to be verified. */
     List_t xEventList = { 0 };
     uint32_t i;
 
@@ -2793,6 +2818,7 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_gt( void )
         xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+
         if( i == 0 )
         {
             /* Core 0 is running an idle task in order to be requested to yield. */
@@ -2878,8 +2904,8 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_gt_null_param( void )
 {
     TCB_t xTaskTCB = { NULL };
     TCB_t xTaskTCBs[ configNUMBER_OF_CORES ] = { NULL };
-    UBaseType_t uxIndexToNotify = 0;    /* Use index 0 in this test. */
-    BaseType_t xSavedInterruptMask = 0x1234;   /* Interrupt mask to be verified. */
+    UBaseType_t uxIndexToNotify = 0;         /* Use index 0 in this test. */
+    BaseType_t xSavedInterruptMask = 0x1234; /* Interrupt mask to be verified. */
     List_t xEventList = { 0 };
     uint32_t i;
 
@@ -2896,6 +2922,7 @@ void test_coverage_vTaskGenericNotifyGiveFromISR_priority_gt_null_param( void )
         xTaskTCBs[ i ].uxPriority = tskIDLE_PRIORITY;
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+
         if( i == 0 )
         {
             /* Core 0 is running an idle task in order to be requested to yield. */
@@ -2986,6 +3013,7 @@ void test_coverage_prvCheckTasksWaitingTermination_multiple_idle_tasks( void )
     prvCheckTasksWaitingTermination();
 
     /* Validation. */
+
     /* No task is waiting to be cleand up. Nothing will be updated in this API. This
      * test case shows its result in the coverage report. */
 }
@@ -3015,7 +3043,7 @@ void test_coverage_prvCheckTasksWaitingTermination_multiple_idle_tasks( void )
  */
 void test_coverage_prvCheckTasksWaitingTermination_delete_not_running_task( void )
 {
-    TCB_t *pxTaskTCB = NULL;
+    TCB_t * pxTaskTCB = NULL;
 
     /* Setup the variables and structure. */
     uxDeletedTasksWaitingCleanUp = 1;
@@ -3023,7 +3051,7 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_not_running_task( void
 
     pxTaskTCB = pvPortMalloc( sizeof( TCB_t ) );
     pxTaskTCB->pxStack = pvPortMalloc( configMINIMAL_STACK_SIZE );
-    pxTaskTCB->xTaskRunState = taskTASK_NOT_RUNNING ;
+    pxTaskTCB->xTaskRunState = taskTASK_NOT_RUNNING;
     pxTaskTCB->xStateListItem.pvOwner = pxTaskTCB;
     pxTaskTCB->xStateListItem.pxContainer = &xTasksWaitingTermination;
     listINSERT_END( &xTasksWaitingTermination, &pxTaskTCB->xStateListItem );
@@ -3070,7 +3098,7 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_not_running_task( void
  */
 void test_coverage_prvCheckTasksWaitingTermination_delete_running_task( void )
 {
-    TCB_t *pxTaskTCB = NULL;
+    TCB_t * pxTaskTCB = NULL;
 
     /* Setup the variables and structure. */
     uxDeletedTasksWaitingCleanUp = 1;
@@ -3078,7 +3106,7 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_running_task( void )
 
     pxTaskTCB = pvPortMalloc( sizeof( TCB_t ) );
     pxTaskTCB->pxStack = pvPortMalloc( configMINIMAL_STACK_SIZE );
-    pxTaskTCB->xTaskRunState = 0 ;
+    pxTaskTCB->xTaskRunState = 0;
     pxTaskTCB->xStateListItem.pvOwner = pxTaskTCB;
     pxTaskTCB->xStateListItem.pxContainer = &xTasksWaitingTermination;
     listINSERT_END( &xTasksWaitingTermination, &pxTaskTCB->xStateListItem );
@@ -3095,6 +3123,7 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_running_task( void )
     prvCheckTasksWaitingTermination();
 
     /* Validation. */
+
     /* If the task is not of taskTASK_NOT_RUNNING state, nothing will be updated.
      * This test shows it's result in coverage report. Verify that the number of
      * deleted task is not changed. */
@@ -3121,11 +3150,11 @@ void test_coverage_prvCheckTasksWaitingTermination_delete_running_task( void )
  *
  * Cover the case where the stack allocation is static.
  */
-void test_coverage_prvDeleteTCB_static_stack_only(void)
+void test_coverage_prvDeleteTCB_static_stack_only( void )
 {
-    TCB_t *pxTaskTCB;
+    TCB_t * pxTaskTCB;
 
-    pxTaskTCB = pvPortMalloc( sizeof(TCB_t) );
+    pxTaskTCB = pvPortMalloc( sizeof( TCB_t ) );
 
     pxTaskTCB->uxPriority = 1;
     pxTaskTCB->xTaskRunState = 0;
@@ -3158,7 +3187,7 @@ void test_coverage_prvDeleteTCB_static_stack_only(void)
  * task being resumed is suspended.
  *
  */
-void test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_greater(void)
+void test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_greater( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     BaseType_t xAlreadyYielded;
@@ -3166,53 +3195,53 @@ void test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_greater(void)
     List_t xList;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the suspended list. */
-    xTaskTCBs[1].uxPriority = 2;
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &xSuspendedTaskList, &xTaskTCBs[1].xStateListItem );
-    vListInitialise(&xList);
+    xTaskTCBs[ 1 ].uxPriority = 2;
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &xSuspendedTaskList, &xTaskTCBs[ 1 ].xStateListItem );
+    vListInitialise( &xList );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     uxTopReadyPriority = 1;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
-    for(uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
+    for( uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
     {
-        if (pxCurrentTCBs[uxCore] == NULL)
+        if( pxCurrentTCBs[ uxCore ] == NULL )
         {
-            pxCurrentTCBs[uxCore] = &xTaskTCBs[0];
+            pxCurrentTCBs[ uxCore ] = &xTaskTCBs[ 0 ];
         }
     }
 
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* Expectations. */
     vFakePortAssertIfInterruptPriorityInvalid_Ignore();
 
     /* API call. */
-    xAlreadyYielded = xTaskResumeFromISR( &xTaskTCBs[1] );
+    xAlreadyYielded = xTaskResumeFromISR( &xTaskTCBs[ 1 ] );
 
     /* Validation. */
     /* The task priority is no higher than current running task. */
     TEST_ASSERT_EQUAL( pdFALSE, xAlreadyYielded );
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
 /** @brief xTaskResumeFromISR - resume task from within ISR context
@@ -3233,7 +3262,7 @@ void test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_greater(void)
  * task being resumed is suspended.
  *
  */
-void test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_lesser(void)
+void test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_lesser( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     BaseType_t xAlreadyYielded;
@@ -3241,53 +3270,53 @@ void test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_lesser(void)
     List_t xList;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the suspended list. */
-    xTaskTCBs[1].uxPriority = 0;
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &xSuspendedTaskList, &xTaskTCBs[1].xStateListItem );
-    vListInitialise(&xList);
+    xTaskTCBs[ 1 ].uxPriority = 0;
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &xSuspendedTaskList, &xTaskTCBs[ 1 ].xStateListItem );
+    vListInitialise( &xList );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     uxTopReadyPriority = 1;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
-    for(uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
+    for( uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
     {
-        if (pxCurrentTCBs[uxCore] == NULL)
+        if( pxCurrentTCBs[ uxCore ] == NULL )
         {
-            pxCurrentTCBs[uxCore] = &xTaskTCBs[0];
+            pxCurrentTCBs[ uxCore ] = &xTaskTCBs[ 0 ];
         }
     }
 
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* Expectations. */
     vFakePortAssertIfInterruptPriorityInvalid_Ignore();
 
     /* API call. */
-    xAlreadyYielded = xTaskResumeFromISR( &xTaskTCBs[1] );
+    xAlreadyYielded = xTaskResumeFromISR( &xTaskTCBs[ 1 ] );
 
     /* Validation. */
     /* The task priority is no higher than current running task. */
     TEST_ASSERT_EQUAL( pdFALSE, xAlreadyYielded );
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
 
@@ -3305,41 +3334,41 @@ void test_coverage_xTaskResumeFromISR_task_suspended_uxpriority_lesser(void)
  * there are tasks and at least one is in the pending ready list.
  *
  */
-void test_coverage_xTaskResumeAll_task_in_pending_ready_list(void)
+void test_coverage_xTaskResumeAll_task_in_pending_ready_list( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     BaseType_t xAlreadyYielded;
     List_t xList;
 
-     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    /* Create a task as current running task on core 0. */
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the pending ready list. */
-    xTaskTCBs[1].uxPriority = 2;        /* The priority is not higher than current running task. */
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &xPendingReadyList, &xTaskTCBs[1].xStateListItem );
-    vListInitialise(&xList);
-    vListInitialiseItem(&(xTaskTCBs[1].xEventListItem));
-    listSET_LIST_ITEM_VALUE(&(xTaskTCBs[1].xEventListItem),
-                          taskEVENT_LIST_ITEM_VALUE_IN_USE);
-    listINSERT_END(&xList, &(xTaskTCBs[1].xEventListItem));
+    xTaskTCBs[ 1 ].uxPriority = 2; /* The priority is not higher than current running task. */
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &xPendingReadyList, &xTaskTCBs[ 1 ].xStateListItem );
+    vListInitialise( &xList );
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xEventListItem ) );
+    listSET_LIST_ITEM_VALUE( &( xTaskTCBs[ 1 ].xEventListItem ),
+                             taskEVENT_LIST_ITEM_VALUE_IN_USE );
+    listINSERT_END( &xList, &( xTaskTCBs[ 1 ].xEventListItem ) );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
     uxTopReadyPriority = 1;
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdTRUE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* Clear setup in commonSetUp. */
     vFakePortReleaseTaskLock_StubWithCallback( NULL );
@@ -3356,9 +3385,9 @@ void test_coverage_xTaskResumeAll_task_in_pending_ready_list(void)
     /* The task priority is no higher than current running task. */
     TEST_ASSERT_EQUAL( pdFALSE, xAlreadyYielded );
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
 /** @brief xTaskResumeAll - resume all suspended tasks
@@ -3375,41 +3404,41 @@ void test_coverage_xTaskResumeAll_task_in_pending_ready_list(void)
  * with a priority less than uxTopReadyPriority.
  *
  */
-void test_coverage_xTaskResumeAll_task_in_pending_ready_list_uxpriority_lesser(void)
+void test_coverage_xTaskResumeAll_task_in_pending_ready_list_uxpriority_lesser( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     BaseType_t xAlreadyYielded;
     List_t xList;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the pending ready list. */
-    xTaskTCBs[1].uxPriority = 0;        /* The priority is not higher than current running task. */
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &xPendingReadyList, &xTaskTCBs[1].xStateListItem );
-    vListInitialise(&xList);
-    vListInitialiseItem(&(xTaskTCBs[1].xEventListItem));
-    listSET_LIST_ITEM_VALUE(&(xTaskTCBs[1].xEventListItem),
-                          taskEVENT_LIST_ITEM_VALUE_IN_USE);
-    listINSERT_END(&xList, &(xTaskTCBs[1].xEventListItem));
+    xTaskTCBs[ 1 ].uxPriority = 0; /* The priority is not higher than current running task. */
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &xPendingReadyList, &xTaskTCBs[ 1 ].xStateListItem );
+    vListInitialise( &xList );
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xEventListItem ) );
+    listSET_LIST_ITEM_VALUE( &( xTaskTCBs[ 1 ].xEventListItem ),
+                             taskEVENT_LIST_ITEM_VALUE_IN_USE );
+    listINSERT_END( &xList, &( xTaskTCBs[ 1 ].xEventListItem ) );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
     uxTopReadyPriority = 1;
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdTRUE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* Clear setup in commonSetUp. */
     vFakePortReleaseTaskLock_StubWithCallback( NULL );
@@ -3426,9 +3455,9 @@ void test_coverage_xTaskResumeAll_task_in_pending_ready_list_uxpriority_lesser(v
     /* The task priority is no higher than current running task. */
     TEST_ASSERT_EQUAL( pdFALSE, xAlreadyYielded );
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
 /**
@@ -3445,7 +3474,7 @@ void test_coverage_xTaskResumeAll_task_in_pending_ready_list_uxpriority_lesser(v
  */
 void test_coverage_vTaskResume_null_task( void )
 {
-    vTaskResume(NULL);
+    vTaskResume( NULL );
 
     /* In this case no state is changed and so no assertion can be made to
      * validate the operation. */
@@ -3473,8 +3502,8 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
 
     xTaskTCBs[ 0 ].uxPriority = 1;
     xTaskTCBs[ 0 ].xTaskRunState = 0;
-    vListInitialiseItem( &( xTaskTCBs[0].xStateListItem ) );
-    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[0].xStateListItem ), &xTaskTCBs[0] );
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     listINSERT_END( &xPendingReadyList, &xTaskTCBs[ 0 ].xStateListItem );
 
     /* Default core ID is 0. The can be changed with vSetCurrentCore. */
@@ -3486,7 +3515,7 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
 
     for( uxCoreID = 0; uxCoreID < configNUMBER_OF_CORES; uxCoreID++ )
     {
-        if (pxCurrentTCBs[ uxCoreID ] == NULL)
+        if( pxCurrentTCBs[ uxCoreID ] == NULL )
         {
             pxCurrentTCBs[ uxCoreID ] = &xTaskTCBs[ 1 ];
         }
@@ -3494,10 +3523,10 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
 
     uxTopReadyPriority = 2;
     uxSchedulerSuspended = pdTRUE;
-    xTaskTCBs[0].ucNotifyState[ xidx ] = taskWAITING_NOTIFICATION;
-    xTaskTCBs[0].ulNotifiedValue[ xidx ] = 0xa5a5;      /* Value to be verified later. */
+    xTaskTCBs[ 0 ].ucNotifyState[ xidx ] = taskWAITING_NOTIFICATION;
+    xTaskTCBs[ 0 ].ulNotifiedValue[ xidx ] = 0xa5a5; /* Value to be verified later. */
 
-    xReturn = xTaskGenericNotify( &xTaskTCBs[0], xidx, 0x0, eNoAction, &prevValue);
+    xReturn = xTaskGenericNotify( &xTaskTCBs[ 0 ], xidx, 0x0, eNoAction, &prevValue );
 
     TEST_ASSERT_EQUAL_UINT32( 0xa5a5, prevValue );
     TEST_ASSERT( xReturn == pdPASS );
@@ -3525,8 +3554,8 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
 
     xTaskTCBs[ 0 ].uxPriority = 2;
     xTaskTCBs[ 0 ].xTaskRunState = 0;
-    vListInitialiseItem( &( xTaskTCBs[0].xStateListItem ) );
-    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[0].xStateListItem ), &xTaskTCBs[0] );
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     listINSERT_END( &xPendingReadyList, &xTaskTCBs[ 0 ].xStateListItem );
 
     /* Default core ID is 0. The can be changed with vSetCurrentCore. */
@@ -3538,7 +3567,7 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
 
     for( uxCoreID = 0; uxCoreID < configNUMBER_OF_CORES; uxCoreID++ )
     {
-        if (pxCurrentTCBs[ uxCoreID ] == NULL)
+        if( pxCurrentTCBs[ uxCoreID ] == NULL )
         {
             pxCurrentTCBs[ uxCoreID ] = &xTaskTCBs[ 1 ];
         }
@@ -3546,10 +3575,10 @@ void test_coverage_xTaskGenericNotify_with_eAction_equalto_eNoAction_taskWAITING
 
     uxTopReadyPriority = 1;
     uxSchedulerSuspended = pdTRUE;
-    xTaskTCBs[0].ucNotifyState[ xidx ] = taskWAITING_NOTIFICATION;
-    xTaskTCBs[0].ulNotifiedValue[ xidx ] = 0xa5a5;      /* Value to be verified later. */
+    xTaskTCBs[ 0 ].ucNotifyState[ xidx ] = taskWAITING_NOTIFICATION;
+    xTaskTCBs[ 0 ].ulNotifiedValue[ xidx ] = 0xa5a5; /* Value to be verified later. */
 
-    xReturn = xTaskGenericNotify( &xTaskTCBs[0], xidx, 0x0, eNoAction, &prevValue);
+    xReturn = xTaskGenericNotify( &xTaskTCBs[ 0 ], xidx, 0x0, eNoAction, &prevValue );
 
     TEST_ASSERT_EQUAL_UINT32( 0xa5a5, prevValue );
     TEST_ASSERT( xReturn == pdPASS );
@@ -3580,7 +3609,7 @@ void test_coverage_vTaskGetInfo_implicit_task( void )
     xTaskTCBs[ 0 ].xTaskRunState = 0;
     xTaskTCBs[ 0 ].uxCoreAffinityMask = ( ( 1U << ( configNUMBER_OF_CORES ) ) - 1U );
     xTaskTCBs[ 0 ].uxTCBNumber = 1;
-    xTaskTCBs[ 0 ].pxStack = ( StackType_t * ) 0x1234;      /* The value to be verified later. */
+    xTaskTCBs[ 0 ].pxStack = ( StackType_t * ) 0x1234; /* The value to be verified later. */
 
     xYieldPendings[ 0 ] = pdFALSE;
     pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
@@ -3725,10 +3754,10 @@ void test_coverage_vTaskGetInfo_get_free_stack_space( void )
     TEST_ASSERT_EQUAL( ( UBaseType_t ) 1, pxTaskStatus.uxCurrentPriority );
     TEST_ASSERT_EQUAL( ( UBaseType_t ) 0, pxTaskStatus.uxBasePriority );
     /* The stack is not used in this test. The high water mark is the index of the stack. */
-    TEST_ASSERT_EQUAL( ( configMINIMAL_STACK_SIZE - 1 ) , pxTaskStatus.usStackHighWaterMark );
+    TEST_ASSERT_EQUAL( ( configMINIMAL_STACK_SIZE - 1 ), pxTaskStatus.usStackHighWaterMark );
 }
 
-/** 
+/**
  * @brief xTaskPriorityInherit - inherit the priority of the mutex holder
  *
  * <b>Coverage</b>
@@ -3745,7 +3774,7 @@ void test_coverage_vTaskGetInfo_get_free_stack_space( void )
  * specified task is less than uxtopreadypriority.
  *
  */
-void test_coverage_xTaskPriorityInherit_task_uxpriority_lesser(void)
+void test_coverage_xTaskPriorityInherit_task_uxpriority_lesser( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     BaseType_t xReturn;
@@ -3753,53 +3782,53 @@ void test_coverage_xTaskPriorityInherit_task_uxpriority_lesser(void)
     List_t xList;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the suspended list. */
-    xTaskTCBs[1].uxPriority = 0;
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ], &xTaskTCBs[1].xStateListItem );
-    vListInitialise(&xList);
+    xTaskTCBs[ 1 ].uxPriority = 0;
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ], &xTaskTCBs[ 1 ].xStateListItem );
+    vListInitialise( &xList );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     uxTopReadyPriority = 1;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
-    for(uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
+    for( uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
     {
-        if (pxCurrentTCBs[uxCore] == NULL)
+        if( pxCurrentTCBs[ uxCore ] == NULL )
         {
-            pxCurrentTCBs[uxCore] = &xTaskTCBs[0];
+            pxCurrentTCBs[ uxCore ] = &xTaskTCBs[ 0 ];
         }
     }
 
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* API call. */
-    xReturn = xTaskPriorityInherit( &xTaskTCBs[1] );
+    xReturn = xTaskPriorityInherit( &xTaskTCBs[ 1 ] );
 
     /* Validation. */
     /* The task priority is no higher than current running task. */
     TEST_ASSERT_EQUAL( pdTRUE, xReturn );
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
-/** 
+/**
  * @brief xTaskPriorityInherit - inherit the priority of the mutex holder
  *
  * <b>Coverage</b>
@@ -3816,7 +3845,7 @@ void test_coverage_xTaskPriorityInherit_task_uxpriority_lesser(void)
  * specified task is greater than uxtopreadypriority.
  *
  */
-void test_coverage_xTaskPriorityInherit_task_uxpriority_greater(void)
+void test_coverage_xTaskPriorityInherit_task_uxpriority_greater( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     BaseType_t xReturn;
@@ -3824,53 +3853,53 @@ void test_coverage_xTaskPriorityInherit_task_uxpriority_greater(void)
     List_t xList;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 3;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 3;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the suspended list. */
-    xTaskTCBs[1].uxPriority = 2;
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ], &xTaskTCBs[1].xStateListItem );
-    vListInitialise(&xList);
+    xTaskTCBs[ 1 ].uxPriority = 2;
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ], &xTaskTCBs[ 1 ].xStateListItem );
+    vListInitialise( &xList );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     uxTopReadyPriority = 1;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
-    for(uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
+    for( uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
     {
-        if (pxCurrentTCBs[uxCore] == NULL)
+        if( pxCurrentTCBs[ uxCore ] == NULL )
         {
-            pxCurrentTCBs[uxCore] = &xTaskTCBs[0];
+            pxCurrentTCBs[ uxCore ] = &xTaskTCBs[ 0 ];
         }
     }
 
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* API call. */
-    xReturn = xTaskPriorityInherit( &xTaskTCBs[1] );
+    xReturn = xTaskPriorityInherit( &xTaskTCBs[ 1 ] );
 
     /* Validation. */
     /* The task priority is no higher than current running task. */
     TEST_ASSERT_EQUAL( pdTRUE, xReturn );
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
-/** 
+/**
  * @brief xTaskPriorityDisinherit - restore priority after inheriting the priority of the mutex holder
  *
  * <b>Coverage</b>
@@ -3886,61 +3915,61 @@ void test_coverage_xTaskPriorityInherit_task_uxpriority_greater(void)
  * is lesser than the uxTopReadyPriority.
  *
  */
-void test_coverage_xTaskPriorityDisinherit_task_uxpriority_lesser(void)
+void test_coverage_xTaskPriorityDisinherit_task_uxpriority_lesser( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     BaseType_t xReturn;
     UBaseType_t uxCore;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the suspended list. */
-    xTaskTCBs[1].uxPriority = 2;
-    xTaskTCBs[1].uxBasePriority = 1;
-    xTaskTCBs[1].uxMutexesHeld++;
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ], &xTaskTCBs[1].xStateListItem );
+    xTaskTCBs[ 1 ].uxPriority = 2;
+    xTaskTCBs[ 1 ].uxBasePriority = 1;
+    xTaskTCBs[ 1 ].uxMutexesHeld++;
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ], &xTaskTCBs[ 1 ].xStateListItem );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     uxTopReadyPriority = 3;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
-    for(uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
+    for( uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
     {
-        if (pxCurrentTCBs[uxCore] == NULL)
+        if( pxCurrentTCBs[ uxCore ] == NULL )
         {
-            pxCurrentTCBs[uxCore] = &xTaskTCBs[0];
+            pxCurrentTCBs[ uxCore ] = &xTaskTCBs[ 0 ];
         }
     }
 
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* API call. */
-    xReturn = xTaskPriorityDisinherit( &xTaskTCBs[1] );
+    xReturn = xTaskPriorityDisinherit( &xTaskTCBs[ 1 ] );
 
     /* Validation. */
     /* The task priority is no higher than current running task. */
     TEST_ASSERT_EQUAL( pdTRUE, xReturn );
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
-/** 
+/**
  * @brief xTaskPriorityDisinherit - restore priority after inheriting the priority of the mutex holder
  *
  * <b>Coverage</b>
@@ -3956,61 +3985,61 @@ void test_coverage_xTaskPriorityDisinherit_task_uxpriority_lesser(void)
  * is lesser than the uxTopReadyPriority.
  *
  */
-void test_coverage_xTaskPriorityDisinherit_task_uxpriority_greater(void)
+void test_coverage_xTaskPriorityDisinherit_task_uxpriority_greater( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     BaseType_t xReturn;
     UBaseType_t uxCore;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the suspended list. */
-    xTaskTCBs[1].uxPriority = 3;
-    xTaskTCBs[1].uxBasePriority = 2;
-    xTaskTCBs[1].uxMutexesHeld++;
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ], &xTaskTCBs[1].xStateListItem );
+    xTaskTCBs[ 1 ].uxPriority = 3;
+    xTaskTCBs[ 1 ].uxBasePriority = 2;
+    xTaskTCBs[ 1 ].uxMutexesHeld++;
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ], &xTaskTCBs[ 1 ].xStateListItem );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     uxTopReadyPriority = 1;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
-    for(uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
+    for( uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
     {
-        if (pxCurrentTCBs[uxCore] == NULL)
+        if( pxCurrentTCBs[ uxCore ] == NULL )
         {
-            pxCurrentTCBs[uxCore] = &xTaskTCBs[0];
+            pxCurrentTCBs[ uxCore ] = &xTaskTCBs[ 0 ];
         }
     }
 
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* API call. */
-    xReturn = xTaskPriorityDisinherit( &xTaskTCBs[1] );
+    xReturn = xTaskPriorityDisinherit( &xTaskTCBs[ 1 ] );
 
     /* Validation. */
     /* The task priority is no higher than current running task. */
     TEST_ASSERT_EQUAL( pdTRUE, xReturn );
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
-/** 
+/**
  * @brief xTaskPriorityDisinheritAfterTimeout - restore priority after inheriting the priority of the mutex holder
  *
  * <b>Coverage</b>
@@ -4026,58 +4055,58 @@ void test_coverage_xTaskPriorityDisinherit_task_uxpriority_greater(void)
  * is lesser than the uxTopReadyPriority.
  *
  */
-void test_coverage_xTaskPriorityDisinheritAfterTimeout_task_uxpriority_lesser(void)
+void test_coverage_xTaskPriorityDisinheritAfterTimeout_task_uxpriority_lesser( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     UBaseType_t uxCore;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the suspended list. */
-    xTaskTCBs[1].uxPriority = 2;
-    xTaskTCBs[1].uxBasePriority = 1;
-    xTaskTCBs[1].uxMutexesHeld++;
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ], &xTaskTCBs[1].xStateListItem );
+    xTaskTCBs[ 1 ].uxPriority = 2;
+    xTaskTCBs[ 1 ].uxBasePriority = 1;
+    xTaskTCBs[ 1 ].uxMutexesHeld++;
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ], &xTaskTCBs[ 1 ].xStateListItem );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     uxTopReadyPriority = 3;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
-    for(uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
+    for( uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
     {
-        if (pxCurrentTCBs[uxCore] == NULL)
+        if( pxCurrentTCBs[ uxCore ] == NULL )
         {
-            pxCurrentTCBs[uxCore] = &xTaskTCBs[0];
+            pxCurrentTCBs[ uxCore ] = &xTaskTCBs[ 0 ];
         }
     }
 
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* API call. */
-    vTaskPriorityDisinheritAfterTimeout( &xTaskTCBs[1], 1 );
+    vTaskPriorityDisinheritAfterTimeout( &xTaskTCBs[ 1 ], 1 );
 
     /* Validation. */
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
-/** 
+/**
  * @brief xTaskPriorityDisinheritAfterTimeout - restore priority after inheriting the priority of the mutex holder
  *
  * <b>Coverage</b>
@@ -4093,55 +4122,55 @@ void test_coverage_xTaskPriorityDisinheritAfterTimeout_task_uxpriority_lesser(vo
  * is lesser than the uxTopReadyPriority.
  *
  */
-void test_coverage_xTaskPriorityDisinheritAfterTimeout_task_uxpriority_greater(void)
+void test_coverage_xTaskPriorityDisinheritAfterTimeout_task_uxpriority_greater( void )
 {
     TCB_t xTaskTCBs[ 2 ] = { NULL };
     UBaseType_t uxCore;
 
     /* Create a task as current running task on core 0. */
-    xTaskTCBs[0].uxPriority = 1;
-    xTaskTCBs[0].xTaskRunState = 0;
-    vListInitialiseItem(&(xTaskTCBs[0].xStateListItem));
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[0].uxPriority ], &xTaskTCBs[0].xStateListItem );
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[0].xStateListItem), &xTaskTCBs[0]);
+    xTaskTCBs[ 0 ].uxPriority = 1;
+    xTaskTCBs[ 0 ].xTaskRunState = 0;
+    vListInitialiseItem( &( xTaskTCBs[ 0 ].xStateListItem ) );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 0 ].uxPriority ], &xTaskTCBs[ 0 ].xStateListItem );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 0 ].xStateListItem ), &xTaskTCBs[ 0 ] );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     /* Create a task in the suspended list. */
-    xTaskTCBs[1].uxPriority = 3;
-    xTaskTCBs[1].uxBasePriority = 2;
-    xTaskTCBs[1].uxMutexesHeld++;
-    xTaskTCBs[1].xTaskRunState = taskTASK_NOT_RUNNING;
-    vListInitialiseItem(&(xTaskTCBs[1].xStateListItem));
-    listSET_LIST_ITEM_OWNER(&(xTaskTCBs[1].xStateListItem), &xTaskTCBs[1]);
-    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ], &xTaskTCBs[1].xStateListItem );
+    xTaskTCBs[ 1 ].uxPriority = 3;
+    xTaskTCBs[ 1 ].uxBasePriority = 2;
+    xTaskTCBs[ 1 ].uxMutexesHeld++;
+    xTaskTCBs[ 1 ].xTaskRunState = taskTASK_NOT_RUNNING;
+    vListInitialiseItem( &( xTaskTCBs[ 1 ].xStateListItem ) );
+    listSET_LIST_ITEM_OWNER( &( xTaskTCBs[ 1 ].xStateListItem ), &xTaskTCBs[ 1 ] );
+    listINSERT_END( &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ], &xTaskTCBs[ 1 ].xStateListItem );
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 
     uxTopReadyPriority = 1;
 
     /* Default value for portGET_CORE_ID is 0. This can be changed with vSetCurrentCore. */
     xYieldPendings[ 0 ] = pdFALSE;
-    pxCurrentTCBs[ 0 ] = &xTaskTCBs[0];
+    pxCurrentTCBs[ 0 ] = &xTaskTCBs[ 0 ];
 
-    for(uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
+    for( uxCore = 0U; uxCore < configNUMBER_OF_CORES; uxCore++ )
     {
-        if (pxCurrentTCBs[uxCore] == NULL)
+        if( pxCurrentTCBs[ uxCore ] == NULL )
         {
-            pxCurrentTCBs[uxCore] = &xTaskTCBs[0];
+            pxCurrentTCBs[ uxCore ] = &xTaskTCBs[ 0 ];
         }
     }
 
     xSchedulerRunning = pdTRUE;
     uxSchedulerSuspended = pdFALSE;
-    xPendedTicks = 0;      /* No pending tick in this test. */
+    xPendedTicks = 0; /* No pending tick in this test. */
 
     /* API call. */
-    vTaskPriorityDisinheritAfterTimeout( &xTaskTCBs[1], 2 );
+    vTaskPriorityDisinheritAfterTimeout( &xTaskTCBs[ 1 ], 2 );
 
     /* Validation. */
     /* The task in pending ready list should not in any event list now. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xEventListItem.pvContainer, NULL );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xEventListItem.pvContainer, NULL );
     /* The task in pending ready list should be added back to ready list. */
-    TEST_ASSERT_EQUAL( xTaskTCBs[1].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[1].uxPriority ] );
+    TEST_ASSERT_EQUAL( xTaskTCBs[ 1 ].xStateListItem.pvContainer, &pxReadyTasksLists[ xTaskTCBs[ 1 ].uxPriority ] );
 }
 
 /**

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
@@ -80,227 +80,236 @@ int suiteTearDown( int numFailures )
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-33
- * The purpose of this test is to verify when multiple CPU cores are available and 
- * the FreeRTOS kernel is configured as (configRUN_MULTIPLE_PRIORITIES = 1) that tasks 
+ * The purpose of this test is to verify when multiple CPU cores are available and
+ * the FreeRTOS kernel is configured as (configRUN_MULTIPLE_PRIORITIES = 1) that tasks
  * of equal priority will execute simultaneously. The kernel will be configured as follows:
-
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 1     Priority –1
  * State - Ready	State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	               Task (TN)
  * Priority – 1                Priority – 1
  * State - Running (Core 0)	   State - Running (Core N)
  */
 void test_priority_verification_tasks_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify all configNUMBER_OF_CORES tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-34
- * The purpose of this test is to verify when multiple CPU cores are available and 
- * the FreeRTOS kernel is configured as (configRUN_MULTIPLE_PRIORITIES = 1) that 
- * tasks of different priorities will execute simultaneously. The kernel will be 
+ * The purpose of this test is to verify when multiple CPU cores are available and
+ * the FreeRTOS kernel is configured as (configRUN_MULTIPLE_PRIORITIES = 1) that
+ * tasks of different priorities will execute simultaneously. The kernel will be
  * configured as follows:
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * One high priority task will be created. N low priority tasks will be created
  * per remaining CPU cores.
- * 
+ *
  * Task (T1)	     Task (TN)
  * Priority – 2      Priority – 1
  * State - Ready	 State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	               Task (TN)
  * Priority – 2                Priority – 1
  * State - Running (Core 0)	   State - Running (Core N)
  */
 void test_priority_verification_tasks_different_priorities( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
-     /* Verify tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    /* Verify tasks are in the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-35
- * A task of equal priority will be created for each available CPU core. 
- * This test will verify that when the priority of one task is lowered the 
+ * A task of equal priority will be created for each available CPU core.
+ * This test will verify that when the priority of one task is lowered the
  * task remains running.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 2     Priority – 2
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 2
  * State - Running (Core 0)	 State - Running (Core N)
- * 
+ *
  * After calling vTaskPrioritySet() and lowering the priority of task T1
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 1              Priority – 2
  * State - Running (Core 0)  State - Running (Core N)
-*/
+ */
 void test_priority_change_tasks_equal_priority_lower( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create tasks of equal priority for all available CPU cores */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Lower the priority of task T0 */
-    vTaskPrioritySet( xTaskHandles[0], 1 );
+    vTaskPrioritySet( xTaskHandles[ 0 ], 1 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandles[0], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
 
     /* Verify all tasks remain in the running state on the same CPU cores */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-36
  * A task of equal priority will be created for each available CPU core.
- * This test will verify that when the priority of one task is raised all  
+ * This test will verify that when the priority of one task is raised all
  * tasks remain running.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 1     Priority – 1
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 1              Priority – 1
  * State - Running (Core 0)	 State - Running (Core N)
- * 
+ *
  * After calling vTaskPrioritySet() and raising the priority of task T1
- * 
+ *
  * Task (T1)	             Task (T2)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)  State - Running (Core N)
-*/
+ */
 void test_priority_change_tasks_equal_priority_raise( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create tasks of equal priority for all available CPU cores */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Raise the priority of task T0 */
-    vTaskPrioritySet( xTaskHandles[0], 2 );
+    vTaskPrioritySet( xTaskHandles[ 0 ], 2 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandles[0], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 2, xTaskDetails.xHandle->uxPriority );
-    
+
     /* Verify T0 is the the running state */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
     /* Verify all tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -311,71 +320,74 @@ void test_priority_change_tasks_equal_priority_raise( void )
  * This test will verify that when the priority of the ready task is raised
  * to match the running tasks it will remain in the ready state. All other
  * tasks will remain in the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	    Task (TN + 1)
  * Priority – 2     Priority – 1
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	             Task (TN + 1)
  * Priority – 2              Priority – 1
  * State - Running (Core N)	 State - Ready
- * 
+ *
  * After calling vTaskPrioritySet() and raising the priority of task TN + 1
- * 
+ *
  * Task (TN)	             Task (TN + 1)
  * Priority – 2              Priority – 2
  * State - Running (Core N)  State - Ready
-*/
+ */
 void test_priority_change_tasks_different_priority_raise_to_equal( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create tasks at high priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify each task is in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Raise the priority of the ready task */
-    vTaskPrioritySet( xTaskHandles[i], 2 );
+    vTaskPrioritySet( xTaskHandles[ i ], 2 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandles[i], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ i ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 2, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the task remains in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify each task is in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -387,74 +399,77 @@ void test_priority_change_tasks_different_priority_raise_to_equal( void )
  * to greater than the running tasks it will enter the running state. All
  * other tasks will remain in the running state except for one. This task will
  * now be in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	    Task (TN + 1)
  * Priority – 2     Priority – 1
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	             Task (TN + 1)
  * Priority – 2              Priority – 1
  * State - Running (Core N)	 State - Ready
- * 
+ *
  * After calling vTaskPrioritySet() and raising the priority of task TN + 1
- * 
+ *
  * Task (TN)	             Task (TN + 1)
  * Priority – 2              Priority – 3
  * State - Running (Core N)  State - Running (Core N)
-*/
+ */
 void test_priority_change_tasks_different_priority_raise_to_higher( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create tasks at high priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify each task is in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Raise the priority of the ready task */
-    vTaskPrioritySet( xTaskHandles[i], 3 );
+    vTaskPrioritySet( xTaskHandles[ i ], 3 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandles[i], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ i ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 3, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the task remains in the state */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify each task is in the running running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**
@@ -464,74 +479,77 @@ void test_priority_change_tasks_different_priority_raise_to_higher( void )
  * This test will verify that when the priority of a running task is lowered
  * to the priority of the existing ready task it will enter the ready state.
  * The previously ready task will now be running.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	    Task (TN + 1)
  * Priority – 2     Priority – 1
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	             Task (TN + 1)
  * Priority – 2              Priority – 1
  * State - Running (Core N)	 State - Ready
- * 
+ *
  * After calling vTaskPrioritySet() and lowering the priority of task T0
- * 
+ *
  * Task (T0)      Task (TN)	                Task (TN + 1)
  * Priority – 1   Priority – 2              Priority – 1
  * State - Ready  State - Running (Core N)  State - Running (Core 0)
-*/
+ */
 void test_priority_change_tasks_different_priority_lower_to_equal( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create tasks at high priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify each task is in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Lower the priority of a running task */
-    vTaskPrioritySet( xTaskHandles[0], 1 );
+    vTaskPrioritySet( xTaskHandles[ 0 ], 1 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandles[0], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the task is now in the ready state */
-    verifySmpTask( &xTaskHandles[0], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eReady, -1 );
 
     /* Verify each other task is in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 }
 
 /**
@@ -541,74 +559,77 @@ void test_priority_change_tasks_different_priority_lower_to_equal( void )
  * This test will verify that when the priority of a running task is set to
  * the lowest priority it will enter the ready state.
  * The previously ready task will now be running.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	    Task (TN + 1)
  * Priority – 3     Priority – 2
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	             Task (TN + 1)
  * Priority – 3              Priority – 2
  * State - Running (Core N)	 State - Ready
- * 
+ *
  * After calling vTaskPrioritySet() and lowering the priority of task T0
- * 
+ *
  * Task (T0)      Task (TN)	                Task (TN + 1)
  * Priority – 1   Priority – 3              Priority – 2
  * State - Ready  State - Running (Core N)  State - Running (Core 0)
-*/
+ */
 void test_priority_change_tasks_different_priority_lower_to_lowest( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create tasks at high priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify each task is in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Lower the priority of a running task */
-    vTaskPrioritySet( xTaskHandles[0], 1 );
+    vTaskPrioritySet( xTaskHandles[ 0 ], 1 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandles[0], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the is now in the ready state */
-    verifySmpTask( &xTaskHandles[0], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eReady, -1 );
 
     /* Verify each other task is in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 }
 
 /**
@@ -617,70 +638,73 @@ void test_priority_change_tasks_different_priority_lower_to_lowest( void )
  * created for each remaining available CPU core. The test will first verify
  * that as each low priority task is deleted the high priority task remains in
  * the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
- * This test can be run with FreeRTOS configured for any number of cores 
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Running (Core N)
- * 
+ *
  * Delete each low priority task
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 2               Priority – 1
  * State - Running (Core 0)	  State - Deleted
  */
 void test_task_delete_tasks_different_priorities_delete_low( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify no tasks are pending deletion */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Delete low priority task */
-        vTaskDelete(xTaskHandles[i]);
+        vTaskDelete( xTaskHandles[ i ] );
 
         /* Verify T0 remains running on core 0 */
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
         /* Verify task T[i] is in the deleted state */
-        verifySmpTask( &xTaskHandles[i], eDeleted, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eDeleted, -1 );
     }
 
     /* Verify tasks are pending deletion */
-    TEST_ASSERT_EQUAL( (configNUMBER_OF_CORES -1 ), uxDeletedTasksWaitingCleanUp );
+    TEST_ASSERT_EQUAL( ( configNUMBER_OF_CORES - 1 ), uxDeletedTasksWaitingCleanUp );
 }
 
 /**
@@ -688,70 +712,73 @@ void test_task_delete_tasks_different_priorities_delete_low( void )
  * A single task of high priority will be created. A low priority task will be
  * created for each remaining available CPU core. The test will delete the high
  * priority task and verify each other core remains in the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
- * This test can be run with FreeRTOS configured for any number of cores 
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Running (Core N)
- * 
+ *
  * Delete the high priority task
- * 
+ *
  * Task (T1)	      Task (TN)
  * Priority – 2       Priority – 1
  * State - Deleted	  State - Running (Core N)
  */
 void test_task_delete_tasks_different_priorities_delete_high( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify no tasks are pending deletion */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
 
     /* Delete task T0 */
-    vTaskDelete(xTaskHandles[0]);
+    vTaskDelete( xTaskHandles[ 0 ] );
 
     /* Verify the task has been deleted */
     TEST_ASSERT_EQUAL( 1, uxDeletedTasksWaitingCleanUp );
-    verifySmpTask( &xTaskHandles[0], eDeleted, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eDeleted, -1 );
 
     /* Verify core 0 is now idle */
-    verifyIdleTask(0, 0);
+    verifyIdleTask( 0, 0 );
 
     /* Verify other cores remain in the running state */
-    for (i = 1; i < (configNUMBER_OF_CORES); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -761,78 +788,81 @@ void test_task_delete_tasks_different_priorities_delete_high( void )
  * additional tasks will be created, a low priority task and a high priority task.
  * This test will verify that when a running high priority task is deleted, the
  * high priority task in the ready state will move to the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
- * This test can be run with FreeRTOS configured for any number of cores 
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)  Task (TN + 2)
  * Priority – 2   Priority – 1   Priority – 2
  * State - Ready  State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	             Task (TN + 1)  Task (TN + 2)
  * Priority – 2              Priority – 1   Priority – 2
  * State - Running (Core N)	 State - Ready  State - Ready
- * 
+ *
  * Delete the high priority task
- * 
+ *
  * Task (T0)	      Task (TN)                 Task (TN + 1)   Task (TN + 2)
  * Priority – 2       Priority – 2              Priority – 1    Priority – 2
  * State - Deleted	  State - Running (Core N)  State - Ready   State - Running (Core 0)
  */
 void test_task_delete_select_high_priority_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 2] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 2 ] = { NULL };
     uint32_t i;
 
     /* Create tasks at high priority for each CPU core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i+1] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i + 1 ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining tasks are in the ready states */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
-    verifySmpTask( &xTaskHandles[i+1], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i + 1 ], eReady, -1 );
 
     /* Verify no tasks are pending deletion */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
 
     /* Delete task T0 */
-    vTaskDelete(xTaskHandles[0]);
+    vTaskDelete( xTaskHandles[ 0 ] );
 
     /* Verify the task has been deleted */
     TEST_ASSERT_EQUAL( 1, uxDeletedTasksWaitingCleanUp );
-    verifySmpTask( &xTaskHandles[0], eDeleted, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eDeleted, -1 );
 
     /* Verify other cores remain in the running state */
-    for (i = 1; i < (configNUMBER_OF_CORES); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* High priority task is now running on core 0 */
-    verifySmpTask( &xTaskHandles[i + 1], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i + 1 ], eRunning, 0 );
 }
 
 /**
@@ -841,60 +871,62 @@ void test_task_delete_select_high_priority_task( void )
  * CPU core will be idle. Once the scheduler is started a new task of equal
  * priority shall be created. The test shall verify the new task is in the
  * running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task N-1
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task N-1
  * Priority – 1
  * State - Running (Core N)
- * 
+ *
  * Create a new task with priority 1
- * 
+ *
  * Task N - 1	             New Task
  * Priority – 1              Priority – 1
  * State - Running (Core N)	 State - Running (Last available core)
- * 
+ *
  */
 void test_task_create_tasks_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining CPU core is running the idle task */
-    verifyIdleTask(0, i);
+    verifyIdleTask( 0, i );
 
     /* Create a new task of equal priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the running state */
-    verifySmpTask( &xTaskHandles[i], eRunning, i );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, i );
 }
 
 /**
@@ -903,60 +935,62 @@ void test_task_create_tasks_equal_priority( void )
  * task will be idle. Once the scheduler is started a new task of lower
  * priority shall be created. The test shall verify the new task is in the
  * running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task N-1
  * Priority – 2
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task N-1
  * Priority – 2
  * State - Running (Core N)
- * 
+ *
  * Create a new task with priority 2
- * 
+ *
  * Task N - 1	             New Task
  * Priority – 2              Priority – 1
  * State - Running (Core N)	 State - Running
- * 
+ *
  */
 void test_task_create_tasks_lower_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining CPU core is running the idle task */
-    verifyIdleTask(0, i);
+    verifyIdleTask( 0, i );
 
     /* Create a new task of lower priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the running state */
-    verifySmpTask( &xTaskHandles[i], eRunning, i );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, i );
 }
 
 /**
@@ -965,61 +999,64 @@ void test_task_create_tasks_lower_priority( void )
  * task will be idle. Once the scheduler is started a new task of higher
  * priority shall be created. The test shall verify the new task is in the
  * running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task N-1
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task N-1
  * Priority – 1
  * State - Running (Core N)
- * 
+ *
  * Create a new task with priority 2
- * 
+ *
  * Task N-1                  New Task
  * Priority – 1              Priority – 2
  * State - Running (Core N)	 State - Running
- * 
+ *
  */
 void test_task_create_tasks_higher_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining CPU core is running the idle task */
-    verifyIdleTask(0, i);
+    verifyIdleTask( 0, i );
 
     /* Create a new task of higher priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     /* Verify all tasks are in the ready state */
-    for (i = 0; i < ( configNUMBER_OF_CORES ); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1028,60 +1065,63 @@ void test_task_create_tasks_higher_priority( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a new task of equal priority is created it will
  * be in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Running (Core N)
- * 
+ *
  * Create a new task of equal priority
- * 
+ *
  * Task (TN)	              New Task
  * Priority – 1               Priority – 1
  * State - Running (Core N)	  State - Ready
  */
 void test_task_create_all_cores_equal_priority_equal( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new task of equal priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify all tasks remain in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1090,60 +1130,63 @@ void test_task_create_all_cores_equal_priority_equal( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a new task of lower priority is created it will
  * be in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Running (Core N)
- * 
+ *
  * Create a new task of lower priority
- * 
+ *
  * Task (TN)	              New Task
  * Priority – 2               Priority – 1
  * State - Running (Core N)	  State - Ready
  */
 void test_task_create_all_cores_equal_priority_lower( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new task of lower priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify all tasks remain in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1153,64 +1196,67 @@ void test_task_create_all_cores_equal_priority_lower( void )
  * test will verify that when a new task of higher priority is created it will
  * be in the running state and a previously running task will now be in the
  * ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Running (Core N)
- * 
+ *
  * Create a new task of higher priority
- * 
+ *
  * Task (TN)	              New Task
  * Priority – 1               Priority – 2
  * State - Running (Core N)	  State - Running
  */
 void test_task_create_all_cores_equal_priority_higher( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new task of higher priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the running state */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify all tasks remain in the running state */
-    for (i = 0; i < (configNUMBER_OF_CORES - 1); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < ( configNUMBER_OF_CORES - 1 ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the last original task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**
@@ -1219,67 +1265,70 @@ void test_task_create_all_cores_equal_priority_higher( void )
  * created for each remaining available CPU core. The test will create a new
  * high priority task and verify the new task is in the running state. A low
  * priority task will also have been moved to the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)       Task (TN)
  * Priority – 2    Priority – 1
  * State - Ready   State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)                  Task (TN)
  * Priority – 2               Priority – 1
  * State - Running (Core 0)   State - Running (Core N)
- * 
+ *
  * Create a new high priority task
- * 
+ *
  * Task (T1)                  Task (TN)                  New Task
  * Priority – 2               Priority – 1               Priority – 2
  * State - Running (Core 0)   State - Running (Core N)   State - Running (Last Core)
  */
 void test_task_create_all_cores_different_priority_high( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create single high priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new high priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the running state */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify all tasks remain in the running state */
-    for (i = 0; i < (configNUMBER_OF_CORES - 1); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < ( configNUMBER_OF_CORES - 1 ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the last original task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**
@@ -1287,63 +1336,66 @@ void test_task_create_all_cores_different_priority_high( void )
  * A single task of high priority will be created. A low priority task will be
  * created for each remaining available CPU core. The test will create a new
  * low priority task and verify the new task is in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)       Task (TN)
  * Priority – 2    Priority – 1
  * State - Ready   State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)                  Task (TN)
  * Priority – 2               Priority – 1
  * State - Running (Core 0)   State - Running (Core N)
- * 
+ *
  * Create a new low priority task
- * 
+ *
  * Task (T1)                  Task (TN)                  New Task
  * Priority – 2               Priority – 1               Priority – 1
  * State - Running (Core 0)   State - Running (Core N)   State - Ready
  */
 void test_task_create_all_cores_different_priority_low( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create single high priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new low priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify all tasks remain in the running state */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1352,77 +1404,81 @@ void test_task_create_all_cores_different_priority_low( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a task is suspended the CPU core will execute
  * the idle task.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – N
  * State - Running (Core N)
- * 
+ *
  * Suspend task (T1)
- * 
+ *
  * Task (T1)	        Task (TN)
  * Priority – 1         Priority – 1
  * State - Suspended	State - Running (Core N)
- * 
+ *
  * Resume task (T1)
- * 
+ *
  * Task (TN)
  * Priority – N
  * State - Running (Core N)
  */
 void test_task_suspend_all_cores_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create tasks of equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Suspend task T0 */
-    vTaskSuspend( xTaskHandles[0] );
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
     /* Verify the task has been suspended */
-    verifySmpTask( &xTaskHandles[0], eSuspended, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eSuspended, -1 );
 
     /* Verify all other tasks are running */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the idle task is running on core 0 */
-    verifyIdleTask(0, 0);
+    verifyIdleTask( 0, 0 );
 
     /* Resume task T0 */
-    vTaskResume( xTaskHandles[0] );
-    
+    vTaskResume( xTaskHandles[ 0 ] );
+
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1432,155 +1488,162 @@ void test_task_suspend_all_cores_equal_priority( void )
  * additional tasks will be created, a low priority task and a high priority task.
  * This test will verify that when a running high priority task is suspended, the
  * high priority task in the ready state will move to the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
- * This test can be run with FreeRTOS configured for any number of cores 
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)  Task (TN + 2)
  * Priority – 2   Priority – 1   Priority – 2
  * State - Ready  State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	             Task (TN + 1)  Task (TN + 2)
  * Priority – 2              Priority – 1   Priority – 2
  * State - Running (Core N)	 State - Ready  State - Ready
- * 
+ *
  * Suspend the high priority task
- * 
+ *
  * Task (T0)	      Task (TN)                 Task (TN + 1)   Task (TN + 2)
  * Priority – 2       Priority – 2              Priority – 1    Priority – 2
  * State - Suspended  State - Running (Core N)  State - Ready   State - Running (Core 0)
  */
 void test_task_suspend_select_high_priority_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 2] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 2 ] = { NULL };
     uint32_t i;
 
     /* Create tasks at high priority for each CPU core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i + 1] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i + 1 ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining tasks are in the ready states */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
-    verifySmpTask( &xTaskHandles[i+1], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i + 1 ], eReady, -1 );
 
     /* Suspend task T0 */
-    vTaskSuspend(xTaskHandles[0]);
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
     /* Verify the task has been suspended */
-    verifySmpTask( &xTaskHandles[0], eSuspended, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eSuspended, -1 );
 
     /* Verify other cores remain in the running state */
-    for (i = 1; i < (configNUMBER_OF_CORES); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* High priority task is now running on core 0 */
-    verifySmpTask( &xTaskHandles[i + 1], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i + 1 ], eRunning, 0 );
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-57
  * A single task of high priority will be created. A low priority task will be
- * created for each remaining available CPU core. The test will verify that 
+ * created for each remaining available CPU core. The test will verify that
  * when the high priority task is suspended the low priority tasks will
  * remain in the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 2               Priority – 1
  * State - Running (Core 0)	  State - Running (Core N)
- * 
+ *
  * Suspend task (T1)
- * 
+ *
  * Task (T1)	       Task (TN)
  * Priority – 2        Priority – 1
  * State - Suspended   State - Running (Core N)
- * 
+ *
  * Resume task (T1)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Running (Core N)
  */
 void test_task_suspend_all_cores_different_priority_suspend_high( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Suspend the high priority task */
-    vTaskSuspend(xTaskHandles[0]);
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
     /* Verify the suspened task is not running. */
-    verifySmpTask( &xTaskHandles[0], eSuspended, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eSuspended, -1 );
 
     /* Verify all other tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify idle task is running on core 0 */
-    verifyIdleTask(0, 0 );
+    verifyIdleTask( 0, 0 );
 
-    vTaskResume( xTaskHandles[0] );
+    vTaskResume( xTaskHandles[ 0 ] );
 
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
     }
 }
 
@@ -1590,80 +1653,84 @@ void test_task_suspend_all_cores_different_priority_suspend_high( void )
  * created for each remaining available CPU core. This test will verify that
  * as each low priority task is suspended, the high priority task shall remain
  * in the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 2               Priority – 1
  * State - Running (Core 0)	  State - Running (Core N)
- * 
+ *
  * Suspend tasks (TN)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)  State - Suspended
- * 
+ *
  * Resume tasks (TN)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Running (Core N)
  */
 void test_task_suspend_all_cores_different_priority_suspend_low( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are running */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
     }
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Suspend low priority task */
-        vTaskSuspend( xTaskHandles[i] );
+        vTaskSuspend( xTaskHandles[ i ] );
 
         /* Verify T0 remains running on core 0 */
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
         /* Verify task T[i] is in the suspended state */
-        verifySmpTask( &xTaskHandles[i], eSuspended, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eSuspended, -1 );
     }
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Resume low priority task */
-        vTaskResume( xTaskHandles[i] );
+        vTaskResume( xTaskHandles[ i ] );
 
         /* Verify T0 remains running on core 0 */
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
         /* Verify task T[i] is in the deleted state */
-        verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - i) );
+        verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - i ) );
     }
 }
 
@@ -1672,160 +1739,168 @@ void test_task_suspend_all_cores_different_priority_suspend_low( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a task is blocked the CPU core will execute
  * the idle task.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – N
  * State - Running (Core N)
- * 
+ *
  * Block task (T1)
- * 
+ *
  * Task (T1)	        Task (TN)
  * Priority – 1         Priority – 1
  * State - Blocked      State - Running (Core N)
- * 
+ *
  * Unblock task (T1)
- * 
+ *
  * Task (TN)
  * Priority – N
  * State - Running (Core N)
  */
 void test_task_blocked_all_cores_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create tasks of equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Block task T0 */
     vTaskDelay( 10 );
 
     /* Verify the task has been suspended */
-    verifySmpTask( &xTaskHandles[0], eBlocked, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eBlocked, -1 );
 
     /* Verify all other tasks are running */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the idle task is running on core 0 */
-    verifyIdleTask(0, 0);
+    verifyIdleTask( 0, 0 );
 
     /* Unblock task T0 */
-    xTaskAbortDelay( xTaskHandles[0] );
-    
+    xTaskAbortDelay( xTaskHandles[ 0 ] );
+
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-60
  * A single task of high priority will be created. A low priority task will be
- * created for each remaining available CPU core. The test will verify that 
+ * created for each remaining available CPU core. The test will verify that
  * when the high priority task is blocked the low priority tasks will
  * remain in the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 2               Priority – 1
  * State - Running (Core 0)	  State - Running (Core N)
- * 
+ *
  * Block task (T1)
- * 
+ *
  * Task (T1)	       Task (TN)
  * Priority – 2        Priority – 1
  * State - Blocked     State - Running (Core N)
- * 
+ *
  * Resume task (T1)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Running (Core N)
  */
 void test_task_blocked_all_cores_different_priority_block_high( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Block the high priority task */
     vTaskDelay( 10 );
 
     /* Verify the blocked task is not running. */
-    verifySmpTask( &xTaskHandles[0], eBlocked, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eBlocked, -1 );
 
     /* Verify all other tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify idle task is running on core 0 */
-    verifyIdleTask(0, 0 );
+    verifyIdleTask( 0, 0 );
 
     /* Unblock task T0 */
-    xTaskAbortDelay( xTaskHandles[0] );
+    xTaskAbortDelay( xTaskHandles[ 0 ] );
 
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
     }
 }
 
@@ -1836,87 +1911,91 @@ void test_task_blocked_all_cores_different_priority_block_high( void )
  * when a high priority task is blocked the low priority task will enter the
  * running state. When the blocked task is resumed, it will move to the running
  * state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	              Task (TN)                 Task (TN + 1)
  * Priority – 2               Priority – 2              Priority – 1
  * State - Running (Core 0)	  State - Running (Core N)	State - Ready
- * 
+ *
  * Block tasks (T1)
- * 
+ *
  * Task (T1)	       Task (TN)                 Task (TN + 1)
  * Priority – 2        Priority – 1              Priority – 1
- * State - Blocked     State - Running (Core N)  State - Running (Core 0) 
- * 
+ * State - Blocked     State - Running (Core N)  State - Running (Core 0)
+ *
  * Unblocked tasks (T1)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Running (Core N)
  */
 void test_task_block_all_cores_high_priority_block( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a task for each CPU core at high priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all high priority tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is ready */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Block the high priority task T0 */
     vTaskDelay( 10 );
 
     /* Verify the task is blocked */
-    verifySmpTask( &xTaskHandles[0], eBlocked, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eBlocked, -1 );
 
     /* Verify all high priority tasks remain running */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is in the running state */
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 
     /* Resume the high priority task */
-    xTaskAbortDelay( xTaskHandles[0] );
+    xTaskAbortDelay( xTaskHandles[ 0 ] );
 
     /* Verify all high priority tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**
@@ -1925,60 +2004,62 @@ void test_task_block_all_cores_high_priority_block( void )
  * additional tasks will be created, a low priority task and a high priority task.
  * This test will verify that when a running high priority task is blocked, the
  * high priority task in the ready state will move to the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
- * This test can be run with FreeRTOS configured for any number of cores 
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)  Task (TN + 2)
  * Priority – 2   Priority – 1   Priority – 2
  * State - Ready  State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	             Task (TN + 1)  Task (TN + 2)
  * Priority – 2              Priority – 1   Priority – 2
  * State - Running (Core N)	 State - Ready  State - Ready
- * 
+ *
  * Blocked the high priority task
- * 
+ *
  * Task (T0)	      Task (TN)                 Task (TN + 1)   Task (TN + 2)
  * Priority – 2       Priority – 2              Priority – 1    Priority – 2
- * State - Blocked 	  State - Running (Core N)  State - Ready   State - Running (Core 0)
+ * State - Blocked    State - Running (Core N)  State - Ready   State - Running (Core 0)
  */
 void test_task_blocked_select_high_priority_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 2] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 2 ] = { NULL };
     uint32_t i;
 
     /* Create tasks at high priority for each CPU core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i+1] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i + 1 ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining tasks are in the ready states */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
-    verifySmpTask( &xTaskHandles[i+1], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i + 1 ], eReady, -1 );
 
     /* Verify no tasks are pending deletion */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
@@ -1987,67 +2068,71 @@ void test_task_blocked_select_high_priority_task( void )
     vTaskDelay( 10 );
 
     /* Verify the task has been blocked */
-    verifySmpTask( &xTaskHandles[0], eBlocked, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eBlocked, -1 );
 
     /* Verify other cores remain in the running state */
-    for (i = 1; i < (configNUMBER_OF_CORES); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* High priority task is now running on core 0 */
-    verifySmpTask( &xTaskHandles[i + 1], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i + 1 ], eRunning, 0 );
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-64
  * A task of equal priority will be created for each available CPU core. The
  * vTaskCoreAffinitySet() API will be used to assign a specific core per task.
- * Once the scheduler has been started the test will verify each task is 
+ * Once the scheduler has been started the test will verify each task is
  * running on the correctly designated core.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	              Task (TN)
  * Priority – 1               Priority – 1
  * Affinity – Last CPU Core   Affinity – (configNUMBER_OF_CORES - 1) - N)
  * State - Ready	          State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Running ((configNUMBER_OF_CORES - 1) - N))
  */
 void test_task_affinity_verification_separate_cores( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create tasks for each CPU core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     /* Normally each task will run on CPU cores in assending order. Assign the lowest
-       tasks to the largest CPU core numbers */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        vTaskCoreAffinitySet(xTaskHandles[i], 1 << ((configNUMBER_OF_CORES - 1) - i) );
+     * tasks to the largest CPU core numbers */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        vTaskCoreAffinitySet( xTaskHandles[ i ], 1 << ( ( configNUMBER_OF_CORES - 1 ) - i ) );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state on the correct CPU Core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, ((configNUMBER_OF_CORES - 1) - i) );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, ( ( configNUMBER_OF_CORES - 1 ) - i ) );
     }
 }
 
@@ -2056,57 +2141,59 @@ void test_task_affinity_verification_separate_cores( void )
  * A task of equal priority will be created for each available CPU core. The
  * vTaskCoreAffinitySet() API will be used to assign the last created task to
  * CPU core 0. The test will verify each task is in the running state except
- * for the last task. The last task will be in the ready state and the idle 
+ * for the last task. The last task will be in the ready state and the idle
  * task will be running on the last available CPU core.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	      Task (TN-1)      Task (Last)
- * Priority – 1       Priority – 1     Priority – 1 
+ * Priority – 1       Priority – 1     Priority – 1
  * Affinity – None    Affinity – None  Affinity - Core 0
  * State - Ready	  State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	             Task (TN-1)               Task (Last)
- * Priority – 1              Priority – 1              Priority – 1 
+ * Priority – 1              Priority – 1              Priority – 1
  * Affinity – None           Affinity – None           Affinity - Core 0
  * State - Running (Core 0)	 State - Running (Core N)  State - Ready
  */
 void test_task_affinity_verification_same_cores( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create tasks for each CPU core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     /* Set core affinity for the last task to CPU 0 */
-    vTaskCoreAffinitySet(xTaskHandles[i-1], 1 << 0 );
+    vTaskCoreAffinitySet( xTaskHandles[ i - 1 ], 1 << 0 );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the last task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify the idle task is running on the last CPU Core */
-    verifyIdleTask(0 , (configNUMBER_OF_CORES - 1) );
+    verifyIdleTask( 0, ( configNUMBER_OF_CORES - 1 ) );
 }
 
 /**
@@ -2117,81 +2204,83 @@ void test_task_affinity_verification_same_cores( void )
  * for the last task. The task running on CPU core 0 will then be suspended.
  * The previously ready task will now be running on CPU core 0. When the
  * suspended task is resumed, it will run on the previously idle CPU core.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	       Task (Last)
- * Priority – 1        Priority – 1 
+ * Priority – 1        Priority – 1
  * Affinity – None     Affinity - Core 0
  * State - Ready	   State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	             Task (TN-1)               Task (Last)
- * Priority – 1              Priority – 1              Priority – 1 
+ * Priority – 1              Priority – 1              Priority – 1
  * Affinity – None           Affinity – None           Affinity - Core 0
  * State - Running (Core 0)	 State - Running (Core N)  State - Ready
- * 
+ *
  * Suspend Task T0
- * 
+ *
  * Task (T0)	         Task (TN-1)               Task (Last)
- * Priority – 1          Priority – 1              Priority – 1 
+ * Priority – 1          Priority – 1              Priority – 1
  * Affinity – None       Affinity – None           Affinity - Core 0
- * State - Suspended     State - Running (Core N)  State - Running (Core 0)	
- * 
+ * State - Suspended     State - Running (Core N)  State - Running (Core 0)
+ *
  * Resume Task T0
- * 
+ *
  * Task (T0)	                Task (TN-1)               Task (Last)
- * Priority – 1                 Priority – 1              Priority – 1 
+ * Priority – 1                 Priority – 1              Priority – 1
  * Affinity – None              Affinity – None           Affinity - Core 0
- * State - Running (Last Core)  State - Running (Core N)  State - Running (Core 0)	
+ * State - Running (Last Core)  State - Running (Core N)  State - Running (Core 0)
  */
 void test_task_affinity_suspend_same_core_affinity( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create tasks for each CPU core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     /* Set the last task to have affinity for core 0 only */
-    vTaskCoreAffinitySet(xTaskHandles[i-1], 1 << 0 );
+    vTaskCoreAffinitySet( xTaskHandles[ i - 1 ], 1 << 0 );
 
     vTaskStartScheduler();
 
     /* Verify all but the last task are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the last task is in the ready state and the last CPU
-    core is idle */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
-    verifyIdleTask(0 , (configNUMBER_OF_CORES - 1) );
+     * core is idle */
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+    verifyIdleTask( 0, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Suspend task T0 */
-    vTaskSuspend( xTaskHandles[0] );
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
     /* Verify the previously ready task is now running on core 0 */
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 
     /* Resume task T0 */
-    vTaskResume( xTaskHandles[0] );
+    vTaskResume( xTaskHandles[ 0 ] );
 
     /* Verify task T0 is now running on the previously
-       idle CPU core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+     * idle CPU core */
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 }
 
 /**
@@ -2200,185 +2289,189 @@ void test_task_affinity_suspend_same_core_affinity( void )
  * vTaskCoreAffinitySet() API will be used to assign the last created task CPU
  * affinity for a core that does not exist. Once the scheduler has been started
  * the test will verify the task does not enter the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	      Task (TN + 1)
  * Priority – 1       Priority – 1
  * Affinity – None    Affinity – Out of range
  * State - Ready	  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 1               Priority – 1
  * Affinity – None            Affinity – Out of range
  * State - Running (Core N)	  State - Ready
- * 
+ *
  * Suspend task T0
- * 
+ *
  * Task (T0)	         Task (TN)                 Task (TN + 1)
- * Priority – 1          Priority – 1              Priority – 1 
+ * Priority – 1          Priority – 1              Priority – 1
  * Affinity – None       Affinity – None           Affinity - Out of range
  * State - Suspended     State - Running (Core N)  State - Ready
  */
 void test_task_affinity_out_of_range( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create tasks for each CPU core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     /* Create an additional task which will be in the ready state */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Set the affinitiy mask to a core that is out of range */
-    vTaskCoreAffinitySet(xTaskHandles[i], 1 << configNUMBER_OF_CORES );
+    vTaskCoreAffinitySet( xTaskHandles[ i ], 1 << configNUMBER_OF_CORES );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify last task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Suspend task T0 */
-    vTaskSuspend( xTaskHandles[0] );
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
     /* Verify last task remains in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-69
  * A single task of high priority will be created. A low priority task will be
- * created for each remaining available CPU core. An additional high priority 
+ * created for each remaining available CPU core. An additional high priority
  * task shall be created in the suspended state and have affinitity for CPU core
  * 0. This test shall verify that when the suspended task is resumed it remains
  * in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	     Task (TN)         Task (TN + 1)
- * Priority – 2      Priority – 1      Priority – 2 
+ * Priority – 2      Priority – 1      Priority – 2
  * Affinity – None   Affinity – None   Affinity - Core 0
  * State - Ready     State - Ready     State - Suspended
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	             Task (TN)                  Task (TN + 1)
- * Priority – 2              Priority – 1               Priority – 2 
+ * Priority – 2              Priority – 1               Priority – 2
  * Affinity – None           Affinity – None            Affinity - Core 0
  * State - Running (Core 0)  State - Running (Core N)   State - Suspended
- * 
+ *
  * Resume task T0
- * 
+ *
  * Task (T0)	             Task (TN)                 Task (TN + 1)
- * Priority – 2              Priority – 1              Priority – 2 
+ * Priority – 2              Priority – 1              Priority – 2
  * Affinity – None           Affinity – None           Affinity – Core 0
  * State - Running (Core 0)  State - Running (Core N)  State - Ready
  */
 void test_task_affinity_resume_suspended_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a high priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create tasks for each remaining CPU core */
-    for (i = 1; i < configNUMBER_OF_CORES ; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     /* Create an additional high priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     /* Suspend task the last task and set core affinity for CPU 0 */
-    vTaskSuspend( xTaskHandles[i] );
-    vTaskCoreAffinitySet(xTaskHandles[i], 1 << 0 );
+    vTaskSuspend( xTaskHandles[ i ] );
+    vTaskCoreAffinitySet( xTaskHandles[ i ], 1 << 0 );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The last task shall be in the suspended state */
-    verifySmpTask( &xTaskHandles[i], eSuspended, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eSuspended, -1 );
 
     /* Resume the last task */
-    vTaskResume(xTaskHandles[i] );
+    vTaskResume( xTaskHandles[ i ] );
 
     /* The last task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-70
  * A single task of high priority will be created. A low priority task will be
- * created for each remaining available CPU core. After the scheduler has been 
+ * created for each remaining available CPU core. After the scheduler has been
  * started an additional high priority task shall be created with affinity for
  * CPU core 0. This task shall be in the ready state. This test shall verify that
  * when the affinity is changed the task will then enter the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	     Task (TN)
  * Priority – 2      Priority – 1
  * Affinity – None   Affinity – None
  * State – Ready     State – Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	             Task (TN)
  * Priority – 2              Priority – 1
  * Affinity – None           Affinity – None
  * State – Running (Core 0)  State – Running (Core N)
- * 
+ *
  * Create a new high priority task with affinity for CPU core 0
- * 
+ *
  * Task (T0)	             Task (TN)                 Task (TN + 1)
- * Priority – 2              Priority – 1              Priority – 2 
+ * Priority – 2              Priority – 1              Priority – 2
  * Affinity – None           Affinity – None           Affinity – Core 0
  * State – Running (Core 0)  State – Running (Core N)  State – Ready
- * 
+ *
  * Remove core affinity on the new task
- * 
+ *
  * Task (T0)	             Task (TN)                 Task (TN + 1)
  * Priority – 2              Priority – 1              Priority – 2
  * Affinity – None           Affinity – None           Affinity – None
@@ -2386,35 +2479,37 @@ void test_task_affinity_resume_suspended_task( void )
  */
 void test_task_affinity_modify_affinity( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a high priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create tasks for each remaining CPU core */
-    for (i = 1; i < configNUMBER_OF_CORES ; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new task with affinity for core 0 */
-    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, (1 << 0), &xTaskHandles[i] );
+    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, ( 1 << 0 ), &xTaskHandles[ i ] );
 
     /* The last task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Allow the task to run on any core */
-    vTaskCoreAffinitySet(xTaskHandles[i], tskNO_AFFINITY );
+    vTaskCoreAffinitySet( xTaskHandles[ i ], tskNO_AFFINITY );
 
     /* Verify the task is now in the running state */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - 1 ) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 }
 
 /**
@@ -2424,116 +2519,118 @@ void test_task_affinity_modify_affinity( void )
  * started a new high priority task will be created with affinity for CPU core 0.
  * This test shall verify the new task remains in the ready state until the
  * priority of the task running on core 0 is lowered.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	      Task (TN)
  * Priority – 2       Priority – 1
  * Affinity – None    Affinity – None
  * State - Ready	  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	              Task (TN)
  * Priority – 2               Priority – 1
  * Affinity – None            Affinity – None
  * State - Running (Core 0)	  State - Running (Core N)
- * 
+ *
  * Create a new high priority task with affinity for core 0
- * 
+ *
  * Task (T0)	             Task (TN)                 Task (TN + 1)
- * Priority – 2              Priority – 1              Priority – 2 
+ * Priority – 2              Priority – 1              Priority – 2
  * Affinity – None           Affinity – None           Affinity – Core 0
  * State - Running (Core 0)  State - Running (Core N)  State - Ready
- * 
+ *
  * Lower the priority of task T0
- * 
+ *
  * Task (T0)	      Task (TN)                 Task (TN + 1)
- * Priority – 1       Priority – 1              Priority – 2 
+ * Priority – 1       Priority – 1              Priority – 2
  * Affinity – None    Affinity – None           Affinity – Core 0
  * State - Ready      State - Running (Core N)  State - Running (Core 0)
  */
 void test_task_affinity_modify_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a high priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create tasks for each remaining CPU core */
-    for (i = 1; i < configNUMBER_OF_CORES ; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new task with affinity for core 0 only */
-    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, (1<< 0), &xTaskHandles[i] );
+    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, ( 1 << 0 ), &xTaskHandles[ i ] );
 
     /* The last task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Lower the priority of task T0 */
-    vTaskPrioritySet( xTaskHandles[0], 1 );
+    vTaskPrioritySet( xTaskHandles[ 0 ], 1 );
 
     /* The new task will now be running on core 0 */
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-68
  * A single task of low priority will be created. A medium priority task will be
  * created for each remaining available CPU core. A task of the highest priority
- * will be created and suspended. After the scheduler has been started the low 
+ * will be created and suspended. After the scheduler has been started the low
  * priority task will have preemption disabled. This test will verify that when the
  * highest priority task is resumed it will not preempt the lowest priority task.
  * Instead it will replace one of the medium priority tasks.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	      Task (TN)         Task (TN + 1)
  * Priority – 1       Priority – 2      Priority – 3
  * State – Ready	  State – Ready     State – Suspended
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	     Task (TN)         Task (TN + 1)
  * Priority – 1      Priority – 2      Priority – 3
  * State - Running	 State - Running   State - Suspended
- * 
+ *
  * Disable preemption on task T0
- * 
+ *
  * Task (T0)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 2      Priority – 3
  * Preemption Disabled
  * State - Running	    State - Running   State - Suspended
- * 
+ *
  * Resume task TN + 1
- * 
+ *
  * Task (T0)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 2      Priority – 3
  * Preemption Disabled
@@ -2541,47 +2638,49 @@ void test_task_affinity_modify_priority( void )
  */
 void test_task_premption_verification( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a single low priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ 0 ] );
 
     /* Create a high priority task task for each remaining CPU core */
-    for (i = 1; i < configNUMBER_OF_CORES ; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a higher priority task which will be suspended */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[i] );
-    vTaskSuspend( xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[ i ] );
+    vTaskSuspend( xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify the low priority task is running on the last available CPU core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify all remaining tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, (i - 1) );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, ( i - 1 ) );
     }
 
     /* Verify the highest priority task is suspended */
-    verifySmpTask( &xTaskHandles[i], eSuspended, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eSuspended, -1 );
 
     /* Disable preemption for task T0 */
-    vTaskPreemptionDisable( xTaskHandles[0] );
+    vTaskPreemptionDisable( xTaskHandles[ 0 ] );
 
     /* Resume the highest priority task. Normally T0 would begin running this
-    task since it is the lowest priority. Since preemption is disabled a 
-    higher priority task is selected instead. */
-    vTaskResume( xTaskHandles[i] );
+     * task since it is the lowest priority. Since preemption is disabled a
+     * higher priority task is selected instead. */
+    vTaskResume( xTaskHandles[ i ] );
 
     /* The highest priority task will run on the first available CPU core */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES -2) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 2 ) );
 
     /* The low priority task remains running on the last core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 }
 
 /**
@@ -2591,37 +2690,37 @@ void test_task_premption_verification( void )
  * started preemption will be disabled on the low priority task. This test will
  * verify that when a new task of the highest priority is created, it will
  * preempt a medium priority task rather than the low priority task.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	      Task (TN)
  * Priority – 1       Priority – 2
  * State – Ready	  State – Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	     Task (TN)
  * Priority – 1      Priority – 2
  * State - Running	 State - Running
- * 
+ *
  * Disable preemption on task T0
- * 
+ *
  * Task (T0)	        Task (TN)
  * Priority – 1         Priority – 2
  * Preemption Disabled
  * State - Running	    State - Running
- * 
+ *
  * Create new task at priority 3
- * 
+ *
  * Task (T0)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 2      Priority – 3
  * Preemption Disabled
@@ -2629,38 +2728,40 @@ void test_task_premption_verification( void )
  */
 void test_task_premption_new_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a single low priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ 0 ] );
 
     /* Create tasks for each remaining CPU core */
-    for (i = 1; i < configNUMBER_OF_CORES ; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the low priority task is running on the last available CPU core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify all remaining tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, (i - 1) );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, ( i - 1 ) );
     }
 
     /* Disable preemption for low priority task T0 */
-    vTaskPreemptionDisable( xTaskHandles[0] );
+    vTaskPreemptionDisable( xTaskHandles[ 0 ] );
 
     /* Create a high priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[ i ] );
 
     /* The new task will now be a CPU core previously running a priority 2 task */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - 2) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 2 ) );
 
     /* The low priority task remains running on the last core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 }
 
 /**
@@ -2669,40 +2770,40 @@ void test_task_premption_new_task( void )
  * created for each remaining available CPU core. An additional low priority task
  * shall be created. After the scheduler has been started the first low priority
  * task will have preemption disabled. This test will verify that when the
- * priority is raised on the low priority task in the ready state it will not 
- * preempt the lowest priority task currently running. Instead it will replace 
+ * priority is raised on the low priority task in the ready state it will not
+ * preempt the lowest priority task currently running. Instead it will replace
  * one of the high priority tasks.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	      Task (TN)         Task (TN + 1)
  * Priority – 1       Priority – 2      Priority – 1
  * State – Ready	  State – Ready     State – Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	     Task (TN)         Task (TN + 1)
  * Priority – 1      Priority – 2      Priority – 1
  * State - Running	 State - Running   State - Ready
- * 
+ *
  * Disable preemption on task T0
- * 
+ *
  * Task (T0)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 2      Priority – 3
  * Preemption Disabled
  * State - Running	    State - Running   State - Ready
- * 
+ *
  * Raise the priority on task TN + 1
- * 
+ *
  * Task (T0)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 2      Priority – 3
  * Preemption Disabled
@@ -2710,44 +2811,46 @@ void test_task_premption_new_task( void )
  */
 void test_task_premption_change_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a single low priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ 0 ] );
 
     /* Create tasks for each remaining CPU core */
-    for (i = 1; i < configNUMBER_OF_CORES ; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a low priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify the low priority task is running on the last available CPU core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify all tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, (i - 1) );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, ( i - 1 ) );
     }
 
     /* Verify the low priority task is not running */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Disable preemption for low priority task T0 */
-    vTaskPreemptionDisable( xTaskHandles[0] );
+    vTaskPreemptionDisable( xTaskHandles[ 0 ] );
 
     /* Raise the priority on the idle low priority task */
-    vTaskPrioritySet( xTaskHandles[i], 3 );
+    vTaskPrioritySet( xTaskHandles[ i ], 3 );
 
     /* The new task will now be a CPU core previously running a priority 2 task */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - 2) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 2 ) );
 
     /* The low priority task remains running on the last core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 }
 
 /**
@@ -2759,89 +2862,91 @@ void test_task_premption_change_priority( void )
  * same core utilized by the low priority task, it shall remain in the ready state.
  * When the new task is allowed to run on any CPU core it will preempt a high
  * priority task rather than the low priority task.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    1
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  * #define configUSE_CORE_AFFINITY                          1
  * #define configUSE_TASK_PREEMPTION_DISABLE                1
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T0)	      Task (TN)
  * Priority – 1       Priority – 2
  * State – Ready	  State – Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T0)	     Task (TN)
  * Priority – 1      Priority – 2
  * State - Running	 State - Running
- * 
+ *
  * Disable preemption on task T0
- * 
+ *
  * Task (T0)	        Task (TN)
  * Priority – 1         Priority – 2
  * Preemption Disabled
  * State - Running	    State - Running
- * 
+ *
  * Create new task at priority 3 with affinity for the same CPU core as task T0
- * 
+ *
  * Task (T0)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 2      Priority – 3
  * Preemption Disabled                    Affinity mask set
  * State - Running	    State - Running   State - Ready
- * 
+ *
  * Clear the affinity mask for Task TN + 1
- * 
+ *
  * Task (T0)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 2      Priority – 3
- * Preemption Disabled                    
+ * Preemption Disabled
  * State - Running	    State - Running   State - Running
  */
 void test_task_premption_change_affinity( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a single low priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ 0 ] );
 
     /* Create tasks for each remaining CPU core */
-    for (i = 1; i < configNUMBER_OF_CORES ; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the low priority task is running on the last available CPU core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify all tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, (i - 1) );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, ( i - 1 ) );
     }
 
     /* Disable preemption for low priority task T0 */
-    vTaskPreemptionDisable( xTaskHandles[0] );
+    vTaskPreemptionDisable( xTaskHandles[ 0 ] );
 
     /* Create a high priority task with affinity for CPU core 0 */
-    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, (1 << (configNUMBER_OF_CORES - 1)), &xTaskHandles[i] );
+    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, ( 1 << ( configNUMBER_OF_CORES - 1 ) ), &xTaskHandles[ i ] );
 
     /* The new task will be in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Allow the task to run on any core */
-    vTaskCoreAffinitySet(xTaskHandles[i], tskNO_AFFINITY );
+    vTaskCoreAffinitySet( xTaskHandles[ i ], tskNO_AFFINITY );
 
     /* The new task will now be a CPU core previously running a priority 2 task */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - 2) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 2 ) );
 
     /* The low priority task remains running on the last core */
-    verifySmpTask( &xTaskHandles[0], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 }
 
 /**
@@ -2874,19 +2979,19 @@ void test_task_premption_change_affinity( void )
  *
  * Task (T0)	        Task (T1)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 1        Priority – 1      Priority – 1
- * State - Running	    State - Ready 	    State - Running   State - Ready
+ * State - Running	    State - Ready       State - Running   State - Ready
  *
  * Task T0 yields on core 0
  *
  * Task (T0)	        Task (T1)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 1        Priority – 1      Priority – 1
- * State - Ready        State - Ready 	    State - Running   State - Running
+ * State - Ready        State - Ready       State - Running   State - Running
  *
  * Task TN yields on core 1
  *
  * Task (T0)	        Task (T1)	        Task (TN)         Task (TN + 1)
  * Priority – 1         Priority – 1        Priority – 1      Priority – 1
- * State - Ready	    State - Running 	State - Ready     State - Running
+ * State - Ready	    State - Running     State - Ready     State - Running
  */
 void test_task_yield_run_wait_longest( void )
 {
@@ -2899,7 +3004,7 @@ void test_task_yield_run_wait_longest( void )
      */
     for( i = 0; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     /* Start the scheduler. The tasks running status:
@@ -2910,15 +3015,16 @@ void test_task_yield_run_wait_longest( void )
      *      TN + 1 : in ready list
      */
     vTaskStartScheduler();
+
     for( i = 0; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
         if( i < configNUMBER_OF_CORES )
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, i );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, i );
         }
         else
         {
-            verifySmpTask( &xTaskHandles[i], eReady, -1 );
+            verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
         }
     }
 
@@ -2932,23 +3038,24 @@ void test_task_yield_run_wait_longest( void )
      */
     vSetCurrentCore( 1 );
     taskYIELD();
+
     for( i = 0; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
         if( i == 1 )
         {
-            verifySmpTask( &xTaskHandles[i], eReady, -1 );
+            verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
         }
         else if( i == ( configNUMBER_OF_CORES + 1 ) )
         {
-            verifySmpTask( &xTaskHandles[i], eReady, -1 );
+            verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
         }
         else if( i == configNUMBER_OF_CORES )
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, 1 );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, 1 );
         }
         else
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, i );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, i );
         }
     }
 
@@ -2962,23 +3069,24 @@ void test_task_yield_run_wait_longest( void )
      */
     vSetCurrentCore( 0 );
     taskYIELD();
+
     for( i = 0; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
         if( ( i == 0 ) || ( i == 1 ) )
         {
-            verifySmpTask( &xTaskHandles[i], eReady, -1 );
+            verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
         }
         else if( i == configNUMBER_OF_CORES )
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, 1 );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, 1 );
         }
         else if( i == ( configNUMBER_OF_CORES + 1 ) )
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
         }
         else
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, i );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, i );
         }
     }
 
@@ -2992,27 +3100,28 @@ void test_task_yield_run_wait_longest( void )
      */
     vSetCurrentCore( 1 );
     taskYIELD();
+
     for( i = 0; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
         if( i == 0 )
         {
-            verifySmpTask( &xTaskHandles[i], eReady, -1 );
+            verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
         }
         else if( i == configNUMBER_OF_CORES )
         {
-            verifySmpTask( &xTaskHandles[i], eReady, -1 );
+            verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
         }
         else if( i == 1 )
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, 1 );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, 1 );
         }
         else if( i == ( configNUMBER_OF_CORES + 1 ) )
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
         }
         else
         {
-            verifySmpTask( &xTaskHandles[i], eRunning, i );
+            verifySmpTask( &xTaskHandles[ i ], eRunning, i );
         }
     }
 }
@@ -3045,13 +3154,13 @@ void test_task_yield_run_wait_longest( void )
  *
  * Task (T0)	        Task (TN-1)	        Task (TN)
  * Priority – 1         Priority – 1        Priority – 1
- * State - Running	    State - Running 	State - Ready
+ * State - Running	    State - Running     State - Ready
  *
  * Task T0 yields on core 0
  *
  * Task (T0)	        Task (TN-1)	        Task (TN)
  * Priority – 1         Priority – 1        Priority – 1
- * State - Ready	    State - Running 	State - Running
+ * State - Ready	    State - Running     State - Running
  */
 void test_task_yield_run_equal_priority_new_task( void )
 {
@@ -3061,17 +3170,17 @@ void test_task_yield_run_equal_priority_new_task( void )
     /* Create N tasks. */
     for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
     {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Create N+1th tasks TN. */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Task T0 yields itself on core 0. */
     taskYIELD();
 
     /* The new task TN should runs on core 0. */
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 }

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/FreeRTOSConfig.h
@@ -43,7 +43,7 @@
 
 /* SMP test specific configuration */
 #define configRUN_MULTIPLE_PRIORITIES                    1
-#define configNUMBER_OF_CORES                                  16
+#define configNUMBER_OF_CORES                            16
 #define configUSE_CORE_AFFINITY                          1
 #define configUSE_TIME_SLICING                           0
 #define configUSE_TASK_PREEMPTION_DISABLE                1
@@ -92,8 +92,8 @@
 /* Run time stats gathering configuration options. */
 unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
 void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that initialises the run time counter. */
-#define configGENERATE_RUN_TIME_STATS    0
-#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+#define configGENERATE_RUN_TIME_STATS             0
+#define portGET_RUN_TIME_COUNTER_VALUE()    ulGetRunTimeCounterValue()
 #define portUSING_MPU_WRAPPERS                    0
 #define portHAS_STACK_OVERFLOW_CHECKING           0
 #define configENABLE_MPU                          0

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/list_macros.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/list_macros.h
@@ -71,4 +71,4 @@ void listINSERT_END( List_t * pxList,
 #undef listREMOVE_ITEM
 void listREMOVE_ITEM( ListItem_t * listItem );
 
-#endif /* ifndef LIST_MACRO_H */    
+#endif /* ifndef LIST_MACRO_H */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/local_portable.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice_mock/local_portable.h
@@ -1,10 +1,10 @@
 #ifndef PORTABLE_H
 #define PORTABLE_H
 void * pvPortMalloc( size_t xSize );
-void vPortFree( void * pv ) ;
+void vPortFree( void * pv );
 StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
-                                             TaskFunction_t pxCode,
-                                             void * pvParameters ) ;
-BaseType_t xPortStartScheduler( void ) ;
-void vPortEndScheduler( void ) ;
-#endif 
+                                     TaskFunction_t pxCode,
+                                     void * pvParameters );
+BaseType_t xPortStartScheduler( void );
+void vPortEndScheduler( void );
+#endif

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_preemption_disable/local_portable.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_preemption_disable/local_portable.h
@@ -12,4 +12,4 @@ StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
 StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
                                      TaskFunction_t pxCode,
                                      void * pvParameters );
-#endif
+#endif /* ifndef LOCAL_PORTABLE_H */

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/FreeRTOSConfig.h
@@ -93,8 +93,8 @@
 /* Run time stats gathering configuration options. */
 unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
 void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that initialises the run time counter. */
-#define configGENERATE_RUN_TIME_STATS    0
-#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+#define configGENERATE_RUN_TIME_STATS             0
+#define portGET_RUN_TIME_COUNTER_VALUE()    ulGetRunTimeCounterValue()
 #define portUSING_MPU_WRAPPERS                    0
 #define portHAS_STACK_OVERFLOW_CHECKING           0
 #define configENABLE_MPU                          0

--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/covg_multiple_priorities_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_timeslice/covg_multiple_priorities_timeslice_utest.c
@@ -159,6 +159,7 @@ void test_coverage_xTaskIncrementTick_no_eq_priority_task( void )
     xReturn = xTaskIncrementTick();
 
     /* Validations. */
+
     /* Core 0 is running a higher priority task. No other task of equal priority is
      * waiting to run. Switching is not required in this test. */
     TEST_ASSERT_EQUAL( pdFALSE, xReturn );
@@ -236,6 +237,7 @@ void test_coverage_xTaskIncrementTick_no_eq_priority_task_yield_pending( void )
     xReturn = xTaskIncrementTick();
 
     /* Validations. */
+
     /* Core 0 is running a higher priority task. No other task of equal priority is
      * waiting to run. However, core 0 has yield pending. Switching is required for
      * core 0. */
@@ -310,6 +312,7 @@ void test_coverage_xTaskIncrementTick_preemption_disabled_task( void )
     xReturn = xTaskIncrementTick();
 
     /* Validations. */
+
     /* Equal priority task is waiting to run. Preemption is disabled for task running
      * on core 0. Switching is not required in this test. */
     TEST_ASSERT_EQUAL( pdFALSE, xReturn );
@@ -394,6 +397,7 @@ void test_coverage_xTaskIncrementTick_ready_higher_priority_delayed_task( void )
     /* Validations. */
     /* Core 0 is running a idle priority task. Switching is required in this test. */
     TEST_ASSERT_EQUAL( pdTRUE, xReturn );
+
     /* The implementation will select the last core to yield for the higher priority
      * task. Verify that the task running on the last core has state taskTASK_YIELDING. */
     TEST_ASSERT_EQUAL( taskTASK_YIELDING, xTaskTCBs[ configNUMBER_OF_CORES - 1 ].xTaskRunState );

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/FreeRTOSConfig.h
@@ -93,8 +93,8 @@
 /* Run time stats gathering configuration options. */
 unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
 void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that initialises the run time counter. */
-#define configGENERATE_RUN_TIME_STATS    0
-#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+#define configGENERATE_RUN_TIME_STATS             0
+#define portGET_RUN_TIME_COUNTER_VALUE()    ulGetRunTimeCounterValue()
 #define portUSING_MPU_WRAPPERS                    0
 #define portHAS_STACK_OVERFLOW_CHECKING           0
 #define configENABLE_MPU                          0

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/covg_single_priority_no_timeslice_utest.c
@@ -48,7 +48,7 @@
 #include "mock_fake_assert.h"
 #include "mock_fake_port.h"
 
-#define MAX_TASKS                                    3
+#define MAX_TASKS    3
 
 /* ===========================  EXTERN FUNCTIONS  =========================== */
 extern void prvCheckForRunStateChange( void );
@@ -56,7 +56,7 @@ extern void prvCheckForRunStateChange( void );
 /* ===========================  EXTERN VARIABLES  =========================== */
 extern volatile UBaseType_t uxDeletedTasksWaitingCleanUp;
 extern volatile UBaseType_t uxSchedulerSuspended;
-extern volatile TCB_t *  pxCurrentTCBs[ configNUMBER_OF_CORES ];
+extern volatile TCB_t * pxCurrentTCBs[ configNUMBER_OF_CORES ];
 extern List_t xSuspendedTaskList;
 extern List_t xPendingReadyList;
 extern volatile UBaseType_t uxTopReadyPriority;
@@ -90,10 +90,11 @@ int suiteTearDown( int numFailures )
 }
 
 /* ==============================  Helper functions for Test Cases  ============================== */
-void created_task(void* arg)
+void created_task( void * arg )
 {
-    while(1){
-        vTaskDelay(100);
+    while( 1 )
+    {
+        vTaskDelay( 100 );
     }
 }
 
@@ -244,71 +245,78 @@ void test_coverage_prvCheckForRunStateChange_first_time_suspend_scheduler( void 
 }
 
 /*
-The kernel will be configured as follows:
-    #define configNUMBER_OF_CORES                               (N > 1)
-    #define configUSE_CORE_AFFINITY                          1
-Coverage for 
-    static TickType_t prvGetExpectedIdleTime( void )      
-*/
+ * The kernel will be configured as follows:
+ #define configNUMBER_OF_CORES                               (N > 1)
+ #define configUSE_CORE_AFFINITY                          1
+ * Coverage for
+ *  static TickType_t prvGetExpectedIdleTime( void )
+ */
+
 /*
-Coverage for: UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
-                                                const UBaseType_t uxArraySize,
-                                                configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
-*/
+ * Coverage for: UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
+ *                                              const UBaseType_t uxArraySize,
+ *                                              configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
+ */
 void test_task_get_system_state( void )
 {
-    TaskStatus_t *tsk_status_array;
-    TaskHandle_t created_handles[3];
-    tsk_status_array = calloc(MAX_TASKS, sizeof(TaskStatus_t));
+    TaskStatus_t * tsk_status_array;
+    TaskHandle_t created_handles[ 3 ];
 
-    for(int i = 0; i < 3; i++){
-        xTaskCreate( created_task, "Created Task", configMINIMAL_STACK_SIZE, NULL, 1, &created_handles[i] );
+    tsk_status_array = calloc( MAX_TASKS, sizeof( TaskStatus_t ) );
+
+    for( int i = 0; i < 3; i++ )
+    {
+        xTaskCreate( created_task, "Created Task", configMINIMAL_STACK_SIZE, NULL, 1, &created_handles[ i ] );
     }
 
-    //Get System states
-    int no_of_tasks = uxTaskGetSystemState(tsk_status_array, MAX_TASKS, NULL);
-    TEST_ASSERT((no_of_tasks > 0) && (no_of_tasks <= MAX_TASKS));
+    /*Get System states */
+    int no_of_tasks = uxTaskGetSystemState( tsk_status_array, MAX_TASKS, NULL );
+    TEST_ASSERT( ( no_of_tasks > 0 ) && ( no_of_tasks <= MAX_TASKS ) );
 }
 
 /*
-Coverage for: UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
-                                                const UBaseType_t uxArraySize,
-                                                configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
-*/
+ * Coverage for: UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
+ *                                              const UBaseType_t uxArraySize,
+ *                                              configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
+ */
 void test_task_get_system_state_custom_time( void )
 {
-    TaskStatus_t *tsk_status_array;
-    TaskHandle_t created_handles[3];
-    uint32_t ulTotalRunTime = (uint32_t) 200;// Custom time value
-    tsk_status_array = calloc(MAX_TASKS, sizeof(TaskStatus_t));
+    TaskStatus_t * tsk_status_array;
+    TaskHandle_t created_handles[ 3 ];
+    uint32_t ulTotalRunTime = ( uint32_t ) 200; /* Custom time value */
 
-    for(int i = 0; i < 3; i++){
-        xTaskCreate( created_task, "Created Task", configMINIMAL_STACK_SIZE, NULL, 1, &created_handles[i] );
+    tsk_status_array = calloc( MAX_TASKS, sizeof( TaskStatus_t ) );
+
+    for( int i = 0; i < 3; i++ )
+    {
+        xTaskCreate( created_task, "Created Task", configMINIMAL_STACK_SIZE, NULL, 1, &created_handles[ i ] );
     }
 
-    //Get System states
-    int no_of_tasks = uxTaskGetSystemState(tsk_status_array, MAX_TASKS, &ulTotalRunTime);
-    TEST_ASSERT((no_of_tasks > 0) && (no_of_tasks <= MAX_TASKS));
+    /*Get System states */
+    int no_of_tasks = uxTaskGetSystemState( tsk_status_array, MAX_TASKS, &ulTotalRunTime );
+    TEST_ASSERT( ( no_of_tasks > 0 ) && ( no_of_tasks <= MAX_TASKS ) );
 }
 
 /*
-Coverage for: UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
-                                                const UBaseType_t uxArraySize,
-                                                configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
-*/
+ * Coverage for: UBaseType_t uxTaskGetSystemState( TaskStatus_t * const pxTaskStatusArray,
+ *                                              const UBaseType_t uxArraySize,
+ *                                              configRUN_TIME_COUNTER_TYPE * const pulTotalRunTime )
+ */
 void test_task_get_system_state_unavilable_task_space( void )
 {
-    TaskStatus_t *tsk_status_array;
-    TaskHandle_t created_handles[3];
-    tsk_status_array = calloc(MAX_TASKS, sizeof(TaskStatus_t));
+    TaskStatus_t * tsk_status_array;
+    TaskHandle_t created_handles[ 3 ];
 
-    for(int i = 0; i < 3; i++){
-        xTaskCreate( created_task, "Created Task", configMINIMAL_STACK_SIZE, NULL, 1, &created_handles[i] );
+    tsk_status_array = calloc( MAX_TASKS, sizeof( TaskStatus_t ) );
+
+    for( int i = 0; i < 3; i++ )
+    {
+        xTaskCreate( created_task, "Created Task", configMINIMAL_STACK_SIZE, NULL, 1, &created_handles[ i ] );
     }
 
-    //Get System states
-    int no_of_tasks = uxTaskGetSystemState(tsk_status_array, MAX_TASKS-1, NULL);
-    TEST_ASSERT((no_of_tasks == 0) && (no_of_tasks <= MAX_TASKS));
+    /*Get System states */
+    int no_of_tasks = uxTaskGetSystemState( tsk_status_array, MAX_TASKS - 1, NULL );
+    TEST_ASSERT( ( no_of_tasks == 0 ) && ( no_of_tasks <= MAX_TASKS ) );
 }
 
 /**
@@ -374,7 +382,7 @@ void test_coverage_vTaskStepTick_eq_task_unblock_time( void )
  * #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
  * {
  *     prvYieldForTask( pxTCB );
- * 
+ *
  *     if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
  *     {
  *         xYieldRequired = pdTRUE;
@@ -393,6 +401,7 @@ void test_coverage_xTaskResumeFromISR_resume_higher_priority_suspended_task( voi
     /* Setup the variables and structure. */
     vListInitialise( &xSuspendedTaskList );
     vListInitialise( &xPendingReadyList );
+
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
         xTaskTCBs[ i ].uxPriority = 1;
@@ -400,6 +409,7 @@ void test_coverage_xTaskResumeFromISR_resume_higher_priority_suspended_task( voi
         xYieldPendings[ i ] = pdFALSE;
         pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
     }
+
     /* A suspended task is created to be resumed from ISR. The task has higher priority
      * than uxTopReadyPriority and the scheduler is suspended. The task will be added
      * to xPendingReadyList after resumed from ISR. */
@@ -431,7 +441,7 @@ void test_coverage_xTaskResumeFromISR_resume_higher_priority_suspended_task( voi
  * #if ( ( configNUMBER_OF_CORES > 1 ) && ( configUSE_PREEMPTION == 1 ) )
  * {
  *     prvYieldForTask( pxTCB );
- * 
+ *
  *     if( xYieldPendings[ portGET_CORE_ID() ] != pdFALSE )
  *     {
  *         xYieldRequired = pdTRUE;
@@ -450,6 +460,7 @@ void test_coverage_xTaskResumeFromISR_resume_lower_priority_suspended_task( void
     /* Setup the variables and structure. */
     vListInitialise( &xSuspendedTaskList );
     vListInitialise( &xPendingReadyList );
+
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
         xTaskTCBs[ i ].uxPriority = 2;
@@ -457,6 +468,7 @@ void test_coverage_xTaskResumeFromISR_resume_lower_priority_suspended_task( void
         xYieldPendings[ i ] = pdFALSE;
         pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
     }
+
     /* A suspended task is created to be resumed from ISR. The task has lower priority
      * than uxTopReadyPriority and the scheduler is suspended. The task will be added
      * to xPendingReadyList after resumed from ISR. */

--- a/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_no_timeslice/single_priority_no_timeslice_utest.c
@@ -80,165 +80,172 @@ int suiteTearDown( int numFailures )
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-1
- * The purpose of this test is to verify when multiple CPU cores are available and 
- * the FreeRTOS kernel is configured as (configRUN_MULTIPLE_PRIORITIES = 0) that tasks 
+ * The purpose of this test is to verify when multiple CPU cores are available and
+ * the FreeRTOS kernel is configured as (configRUN_MULTIPLE_PRIORITIES = 0) that tasks
  * of equal priority will execute simultaneously. The kernel will be configured as follows:
-
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 1     Priority –1
  * State - Ready	State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	               Task (TN)
  * Priority – 1                Priority – 1
  * State - Running (Core 0)	   State - Running (Core N)
  */
 void test_priority_verification_tasks_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify all configNUMBER_OF_CORES tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-2
- * The purpose of this test is to verify when multiple CPU cores are available and 
- * the FreeRTOS kernel is configured as (configRUN_MULTIPLE_PRIORITIES = 0) that 
+ * The purpose of this test is to verify when multiple CPU cores are available and
+ * the FreeRTOS kernel is configured as (configRUN_MULTIPLE_PRIORITIES = 0) that
  * tasks of different priorities will not execute simultaneously. The kernel will be
  * configured as follows:
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * One high priority task will be created. N low priority tasks will be created
  * per remaining CPU cores.
- * 
+ *
  * Task (T1)	     Task (TN)
  * Priority – 2      Priority – 1
  * State - Ready	 State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	               Task (TN)
  * Priority – 2                Priority – 1
  * State - Running (Core 0)	   State - Ready
  */
 void test_priority_verification_tasks_different_priorities( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask( i-1, i);
+        verifyIdleTask( i - 1, i );
     }
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-3
- * A task of equal priority will be created for each available CPU core. 
- * This test will verify that when the priority of one task is lowered the 
+ * A task of equal priority will be created for each available CPU core.
+ * This test will verify that when the priority of one task is lowered the
  * task is no longer running.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 2     Priority – 2
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 2
  * State - Running (Core 0)	 State - Running (Core N)
- * 
+ *
  * After calling vTaskPrioritySet() and lowering the priority of task T1
- * 
+ *
  * Task (T1)	   Task (TN)
  * Priority – 1    Priority – 2
  * State - Ready   State - Running (Core N)
-*/
+ */
 void test_priority_change_tasks_equal_priority_lower( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create tasks of equal priority for all available CPU cores */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Lower the priority of task T0 */
-    vTaskPrioritySet( xTaskHandles[0], 1 );
+    vTaskPrioritySet( xTaskHandles[ 0 ], 1 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandles[0], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
-    
+
     /* Verify T0 is the the ready state */
-    verifySmpTask( &xTaskHandles[0], eReady, -1 );
-    
+    verifySmpTask( &xTaskHandles[ 0 ], eReady, -1 );
+
     /* Verify the idle task is now running on CPU core 0 */
-    verifyIdleTask(0, 0);
+    verifyIdleTask( 0, 0 );
 
     /* Verify all other tasks remain in the running state on the same CPU cores */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -247,66 +254,69 @@ void test_priority_change_tasks_equal_priority_lower( void )
  * A task of equal priority will be created for each available CPU core.
  * This test will verify that when the priority of one task is raised it
  * shall remain running and all other tasks will enter the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 1     Priority – 1
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 1              Priority – 1
  * State - Running (Core 0)	 State - Running (Core N)
- * 
+ *
  * After calling vTaskPrioritySet() and raising the priority of task T1
- * 
+ *
  * Task (T1)	             Task (T2)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)  State - Ready
-*/
+ */
 void test_priority_change_tasks_equal_priority_raise( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create tasks of equal priority for all available CPU cores */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Raise the priority of task T0 */
-    vTaskPrioritySet( xTaskHandles[0], 2 );
+    vTaskPrioritySet( xTaskHandles[ 0 ], 2 );
 
     /* Verify the priority has been changed */
-    vTaskGetInfo( xTaskHandles[0], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 2, xTaskDetails.xHandle->uxPriority );
-    
-    /* Verify T0 is the the running state */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    /* Verify T0 is the the running state */
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
+
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the ready state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 }
 
@@ -316,69 +326,72 @@ void test_priority_change_tasks_equal_priority_raise( void )
  * created for each remaining available CPU core. The test will first verify
  * only the high priority task is in the running state. Each low priority task
  * will then be raised to high priority and enter the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
  *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	   Task (TN)
  * Priority – 2    Priority – 1
  * State - Ready   State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
- * 
+ *
  * After calling vTaskPrioritySet() and raising the priority of tasks TN
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 2
  * State - Running (Core 0)	 State - Running (Core N)
  */
 void test_priority_change_tasks_different_priority_raise( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Raise the priority of the task */
-        vTaskPrioritySet( xTaskHandles[i], 2 );
+        vTaskPrioritySet( xTaskHandles[ i ], 2 );
 
         /* Verify the priority has been rasied */
-        vTaskGetInfo( xTaskHandles[i], &xTaskDetails, pdTRUE, eInvalid );
+        vTaskGetInfo( xTaskHandles[ i ], &xTaskDetails, pdTRUE, eInvalid );
         TEST_ASSERT_EQUAL( 2, xTaskDetails.xHandle->uxPriority );
 
         /* Verify the task is now in the running state */
-        verifySmpTask( &xTaskHandles[i], eRunning, configNUMBER_OF_CORES - i );
+        verifySmpTask( &xTaskHandles[ i ], eRunning, configNUMBER_OF_CORES - i );
     }
 }
 
@@ -389,65 +402,67 @@ void test_priority_change_tasks_different_priority_raise( void )
  * only the high priority task is in the running state. The high priority task
  * shall be lowered. This will cause all low priority tasks to enter the running
  * state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater
  * than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 2     Priority –1
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
- * 
+ *
  * After calling vTaskPrioritySet() and lowering the
  * priority of all low priority tasks.
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 1               Priority – 1
  * State - Running (Core 0)	  State - Running (Core N)
  */
 void test_priority_change_tasks_different_priority_lower( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
     TaskStatus_t xTaskDetails;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
     /* Lower the priority of the high priority task to match all other tasks */
-    vTaskPrioritySet( xTaskHandles[0], 1 ); //After this returns task[0] is not running, task[1] is running on 0
+    vTaskPrioritySet( xTaskHandles[ 0 ], 1 ); /*After this returns task[0] is not running, task[1] is running on 0 */
 
     /* Verify the priority has been lowered */
-    vTaskGetInfo( xTaskHandles[0], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL( 1, xTaskDetails.xHandle->uxPriority );
 
     /* Verify the task remains running. When priority dropped in prvSelectHighestPriorityTask.
@@ -459,11 +474,12 @@ void test_priority_change_tasks_different_priority_lower( void )
      * Core N-2 choose xTaskHandles[N-1]
      * Core N-1 choose xTaskHandles[0]
      */
-    verifySmpTask( &xTaskHandles[0], eRunning, ( BaseType_t )( configNUMBER_OF_CORES - 1 ) );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, ( BaseType_t ) ( configNUMBER_OF_CORES - 1 ) );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the running state */
-        verifySmpTask( &xTaskHandles[i], eRunning, ( BaseType_t)( i - 1 ) );
+        verifySmpTask( &xTaskHandles[ i ], eRunning, ( BaseType_t ) ( i - 1 ) );
     }
 }
 
@@ -473,58 +489,60 @@ void test_priority_change_tasks_different_priority_lower( void )
  * tasks will be idle. Once the scheduler is started a new task of equal
  * priority shall be created. The test shall verify the new task is in the
  * running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task N-1
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task N-1
  * Priority – 1
  * State - Running (Core N)
- * 
+ *
  * Create a new task with priority 1
- * 
+ *
  * Task N - 1	             New Task
  * Priority – 1              Priority – 1
  * State - Running (Core N)	 State - Running (Last available core)
- * 
+ *
  */
 void test_task_create_tasks_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining CPU core is running the idle task */
-    verifyIdleTask(0, i);
+    verifyIdleTask( 0, i );
 
     /* Create a new task of equal priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the running state */
-    verifySmpTask( &xTaskHandles[i], eRunning, i );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, i );
 }
 
 /**
@@ -533,58 +551,60 @@ void test_task_create_tasks_equal_priority( void )
  * task will be idle. Once the scheduler is started a new task of lower
  * priority shall be created. The test shall verify the new task is in the
  * ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task N-1
  * Priority – 2
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task N-1
  * Priority – 2
  * State - Running (Core N)
- * 
+ *
  * Create a new task with priority 2
- * 
+ *
  * Task N - 1	             New Task
  * Priority – 2              Priority – 1
  * State - Running (Core N)	 State - Ready
- * 
+ *
  */
 void test_task_create_tasks_lower_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining CPU core is running the idle task */
-    verifyIdleTask(0, i);
+    verifyIdleTask( 0, i );
 
     /* Create a new task of lower priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**
@@ -593,41 +613,42 @@ void test_task_create_tasks_lower_priority( void )
  * task will be idle. Once the scheduler is started a new task of higher
  * priority shall be created. The test shall verify the new task is in the
  * running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task N-1
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task N-1
  * Priority – 1
  * State - Running (Core N)
- * 
+ *
  * Create a new task with priority 2
- * 
+ *
  * Task N - 1        New Task
  * Priority – 1      Priority – 2
  * State - Ready	 State - Running (Core N)
- * 
+ *
  */
 void test_task_create_tasks_higher_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i, xCoreToRunTask;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* The task running status on each core after scheduler started:
@@ -641,12 +662,13 @@ void test_task_create_tasks_higher_priority( void )
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES - 1; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify remaining CPU core is running the idle task */
-    verifyIdleTask(0, i);
+    verifyIdleTask( 0, i );
 
     /* Create a new task of higher priority. prvYieldForTask will be called to yield
      * for this task. Since all the core has lower priority than this task. These cores
@@ -663,25 +685,28 @@ void test_task_create_tasks_higher_priority( void )
      * core N - 2 choose xIdleTaskHandles[N-3]
      * core 0 choose xIdleTaskHandles[N-2]
      */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 3, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the running state. The created task will increase the priority */
     xCoreToRunTask = 1;
+
     if( xCoreToRunTask == ( configNUMBER_OF_CORES - 1 ) )
     {
         /* Core 1 is the last core ( configNUMBER_OF_CORES - 1 ), then it is already running
          * idle task. The last core to choose task is core 0. */
         xCoreToRunTask = 0;
     }
-    verifySmpTask( &xTaskHandles[i], eRunning, xCoreToRunTask );
+
+    verifySmpTask( &xTaskHandles[ i ], eRunning, xCoreToRunTask );
 
     /* Verify all tasks are in the ready state */
-    for (i = 0; i < ( configNUMBER_OF_CORES - 1 ); i++) {
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    for( i = 0; i < ( configNUMBER_OF_CORES - 1 ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
     }
 
     /* Verify all the idle task running. */
-    for (i = 0; i < configNUMBER_OF_CORES; i++)
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
         if( i == xCoreToRunTask )
         {
@@ -690,7 +715,7 @@ void test_task_create_tasks_higher_priority( void )
         else if( i == 0 )
         {
             /* Core 0 choose the last. It chooses the configNUMBER_OF_CORES - 2 idle task. */
-            verifyIdleTask( ( BaseType_t )( configNUMBER_OF_CORES - 2 ), i );
+            verifyIdleTask( ( BaseType_t ) ( configNUMBER_OF_CORES - 2 ), i );
         }
         else if( i == ( configNUMBER_OF_CORES - 1 ) )
         {
@@ -699,7 +724,7 @@ void test_task_create_tasks_higher_priority( void )
         }
         else
         {
-            verifyIdleTask( ( BaseType_t )( i - 1 ), i );
+            verifyIdleTask( ( BaseType_t ) ( i - 1 ), i );
         }
     }
 }
@@ -709,58 +734,61 @@ void test_task_create_tasks_higher_priority( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a new task of equal priority is created it will
  * be in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Running (Core N)
- * 
+ *
  * Create a new task of equal priority
- * 
+ *
  * Task (TN)	              New Task
  * Priority – 1               Priority – 1
  * State - Running (Core N)	  State - Ready
  */
 void test_task_create_all_cores_equal_priority_equal( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new task of equal priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify all tasks remain in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -769,58 +797,61 @@ void test_task_create_all_cores_equal_priority_equal( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a new task of lower priority is created it will
  * be in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Running (Core N)
- * 
+ *
  * Create a new task of lower priority
- * 
+ *
  * Task (TN)	              New Task
  * Priority – 2               Priority – 1
  * State - Running (Core N)	  State - Ready
  */
 void test_task_create_all_cores_equal_priority_lower( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new task of lower priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify all tasks remain in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -829,40 +860,41 @@ void test_task_create_all_cores_equal_priority_lower( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a new task of higher priority is created it will
  * be in the running state and all other tasks will now be in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Running (Core N)
- * 
+ *
  * Create a new task of higher priority
- * 
+ *
  * Task (TN)	              New Task
  * Priority – 2               Priority – 1
  * State - Running (Core N)	  State - Ready
  */
 void test_task_create_all_cores_equal_priority_higher( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     /* After start scheduler, core choose task status:
@@ -873,12 +905,14 @@ void test_task_create_all_cores_equal_priority_higher( void )
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Create a new task of higher priority */
-    /* The created task has higher priority than other tasks. This will casue all 
+
+    /* The created task has higher priority than other tasks. This will casue all
      * the other cores yield. The task is choosed by core yield order which is accending
      * in vYieldCores. Since core 0 create the task, it will yield last due to the mock
      * implementation.
@@ -888,14 +922,15 @@ void test_task_create_all_cores_equal_priority_higher( void )
      * core N-1 choose xIdleTaskHandles[N-3]
      * core 0 choose xIdleTaskHandles[N-2]
      */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eRunning, 1 );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 1 );
 
     /* Verify all tasks remain in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
     }
 
     /* Verify all the idle task. */
@@ -903,7 +938,7 @@ void test_task_create_all_cores_equal_priority_higher( void )
     {
         if( i == 0 )
         {
-            verifyIdleTask(configNUMBER_OF_CORES - 2, i);
+            verifyIdleTask( configNUMBER_OF_CORES - 2, i );
         }
         else if( i == 1 )
         {
@@ -911,7 +946,7 @@ void test_task_create_all_cores_equal_priority_higher( void )
         }
         else
         {
-            verifyIdleTask(i - 2, i);
+            verifyIdleTask( i - 2, i );
         }
     }
 }
@@ -923,67 +958,70 @@ void test_task_create_all_cores_equal_priority_higher( void )
  * a new task is created at priority equal to the running task it will be in
  * the running state. The original low priority task will remain in the ready
  * state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 2     Priority – 1
  * State - Running	State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
- * 
+ *
  * Create a new task at the same priority as task (T1)
- * 
+ *
  * Task (T1)	              Task (TN)	     New Task
  * Priority – 2               Priority – 1   Priority – 2
  * State - Running (Core 0)	  State - Ready  State - Running (Core 1)
- */ 
+ */
 void test_task_create_all_cores_different_priority_high( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
     /* Create a new task of high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the running state */
-    verifySmpTask( &xTaskHandles[i], eRunning, (configNUMBER_OF_CORES - 1) );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify all tasks remain in the ready state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
     }
 }
 
@@ -993,133 +1031,139 @@ void test_task_create_all_cores_different_priority_high( void )
  * be created for each remaining available CPU core. This test will verify when
  * a new task is created at low priority it will be in the ready state. The
  * original low priority tasks will also remain in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	    Task (TN)
  * Priority – 2     Priority – 1
  * State - Running	State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
- * 
+ *
  * Create a new task at the same priority as task (T1)
- * 
+ *
  * Task (T1)	              Task (TN)	     New Task
  * Priority – 2               Priority – 1   Priority – 1
  * State - Running (Core 0)	  State - Ready  State - Ready
- */ 
+ */
 void test_task_create_all_cores_different_priority_low( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
     /* Create a new task of high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     /* Verify the new task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify all tasks remain in the ready state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
     }
 }
 
 /**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-15
- * Tasks of equal priority shall be created for each available CPU core. 
+ * Tasks of equal priority shall be created for each available CPU core.
  * This test will verify when a task is deleted the remaining tasks are still
  * in the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	   Task (TN)
  * Priority – 1    Priority – 1
- * State - Ready   State - Ready	
- * 
+ * State - Ready   State - Ready
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 1               Priority – 1
  * State - Running (Core 0)	  State - Running (Core N)
- * 
+ *
  * Delete task (T1)
- * 
+ *
  * Task (T1)	              Task (TN)
- * Priority – 1 	          Priority – 1
+ * Priority – 1               Priority – 1
  * State - Deleted            State - Running (Core N)
  */
 void test_task_delete_tasks_equal_priority_delete_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create all tasks at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify no tasks are pending deletion */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
 
     /* Delete task T0 */
-    vTaskDelete(xTaskHandles[0]);
+    vTaskDelete( xTaskHandles[ 0 ] );
 
     /* Verify a single task is pending deletion */
     TEST_ASSERT_EQUAL( 1, uxDeletedTasksWaitingCleanUp );
 
     /* Verify task T0 is in the deleted state */
-    verifySmpTask( &xTaskHandles[0], eDeleted, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eDeleted, -1 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all remaining tasks are still running */
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1129,70 +1173,73 @@ void test_task_delete_tasks_equal_priority_delete_task( void )
  * created for each remaining available CPU core. The test will first verify
  * only the high priority task is in the running state. Each low priority task
  * will then be deleted.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
- * This test can be run with FreeRTOS configured for any number of cores 
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
- * 
+ *
  * Delete each low priority task
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 2               Priority – 1
  * State - Running (Core 0)	  State - Deleted
  */
 void test_task_delete_tasks_different_priorities_delete_low( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[1], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ 1 ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
     /* Verify no tasks are pending deletion */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Delete low priority task */
-        vTaskDelete(xTaskHandles[i]);
+        vTaskDelete( xTaskHandles[ i ] );
 
         /* Verify T0 remains running on core 0 */
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
         /* Verify task T[i] is in the deleted state */
-        verifySmpTask( &xTaskHandles[i], eDeleted, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eDeleted, -1 );
     }
 
     /* Remains 0 since all deleted tasks were not running */
@@ -1205,71 +1252,74 @@ void test_task_delete_tasks_different_priorities_delete_low( void )
  * created for each remaining available CPU core. The test will first verify
  * only the high priority task is in the running state. The high priority task
  * will then be deleted.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
- * This test can be run with FreeRTOS configured for any number of cores 
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
- * 
+ *
  * Delete the high priority task
- * 
+ *
  * Task (T1)	      Task (TN)
  * Priority – 2       Priority – 1
  * State - Deleted	  State - Running (Core 0)
  */
 void test_task_delete_tasks_different_priorities_delete_high( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[1], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ 1 ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
     /* Verify no tasks are pending deletion */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
 
     /* Delete task T0 */
-    vTaskDelete(xTaskHandles[0]);
+    vTaskDelete( xTaskHandles[ 0 ] );
 
     /* Verify the task has been deleted */
     TEST_ASSERT_EQUAL( 1, uxDeletedTasksWaitingCleanUp );
-    verifySmpTask( &xTaskHandles[0], eDeleted, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eDeleted, -1 );
 
     /* Verify all previous ready tasks are now running */
-    for (i = 1; i < (configNUMBER_OF_CORES); i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i -1 );
+    for( i = 1; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i - 1 );
     }
 }
 
@@ -1278,26 +1328,26 @@ void test_task_delete_tasks_different_priorities_delete_high( void )
  * Tasks of equal priority shall be created for each available CPU core.
  * One additional task shall be created while will be idle. This test will
  * verify when a task is deleted the idle task will begin running.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)	      Task (TN + 1)
  * Priority – 1   Priority – 1    Priority - 1
- * State - Ready  State - Ready   State - Ready	
- * 
+ * State - Ready  State - Ready   State - Ready
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	            Task (TN)	              Task (T2)
  * Priority – 1             Priority – 1              Priority – 1
  * State - Running (Core 0)	State - Running (Core N)  State - Ready
- * 
+ *
  * Delete task (T1)
  * Task (T1)	    Task (TN)	              Task (T3)
  * Priority – 1     Priority – 1              Priority – 1
@@ -1305,42 +1355,45 @@ void test_task_delete_tasks_different_priorities_delete_high( void )
  */
 void test_task_delete_tasks_equal_priority_delete_running( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES + 1 tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES + 1); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES + 1 ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify tasks are running and one task is ready */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify there are no deleted tasks pending cleanup */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
 
     /* Delete task 1 running on core 0 */
-    vTaskDelete(xTaskHandles[0]);
+    vTaskDelete( xTaskHandles[ 0 ] );
 
     /* Verify a deleted task is now pending cleanup */
     TEST_ASSERT_EQUAL( 1, uxDeletedTasksWaitingCleanUp );
 
     /* Verify task T0 has been deleted */
-    verifySmpTask( &xTaskHandles[0], eDeleted, -1 );
-    
-    for (i = 1; i < (configNUMBER_OF_CORES); i++) {
+    verifySmpTask( &xTaskHandles[ 0 ], eDeleted, -1 );
+
+    for( i = 1; i < ( configNUMBER_OF_CORES ); i++ )
+    {
         /* Verify all other tasks are in the running state */
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The last task will be running on core 0 */
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 }
 
 /**
@@ -1349,76 +1402,79 @@ void test_task_delete_tasks_equal_priority_delete_running( void )
  * priority task will also be created and be in the ready state. This test
  * will verify that when a high priority task is deleted the low priority task
  * will remain in the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)
  * Priority – 2   Priority - 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	             Task (TN + 1)
  * Priority – 2              Priority - 1
  * State - Running (Core N)	 State - Ready
- * 
+ *
  * Delete task (T0)
- * 
+ *
  * Task (T0)	     Task (TN)	               Task (TN + 1)
  * Priority – 2      Priority – 2              Priority – 1
  * State - Deleted	 State - Running (Core N)  State - Ready
  */
 void test_task_delete_all_cores_high_priority_delete_high_priority_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create tasks of high priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task of low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify tasks are running and one task is ready */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Verify there are no deleted tasks pending cleanup */
     TEST_ASSERT_EQUAL( 0, uxDeletedTasksWaitingCleanUp );
 
     /* Delete task running on core 0 */
-    vTaskDelete(xTaskHandles[0]);
+    vTaskDelete( xTaskHandles[ 0 ] );
 
     /* Verify a deleted task is now pending cleanup */
     TEST_ASSERT_EQUAL( 1, uxDeletedTasksWaitingCleanUp );
 
     /* Verify task T0 has been deleted */
-    verifySmpTask( &xTaskHandles[0], eDeleted, -1 );
-    
-    /* Verify core 0 is now idle */
-    verifyIdleTask(0, 0);
+    verifySmpTask( &xTaskHandles[ 0 ], eDeleted, -1 );
 
-    for (i = 1; i < (configNUMBER_OF_CORES); i++) {
+    /* Verify core 0 is now idle */
+    verifyIdleTask( 0, 0 );
+
+    for( i = 1; i < ( configNUMBER_OF_CORES ); i++ )
+    {
         /* Verify all other tasks are in the running state */
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The last task will remain in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 }
 
 /**
@@ -1426,75 +1482,79 @@ void test_task_delete_all_cores_high_priority_delete_high_priority_task( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a task is suspended the CPU core will execute
  * the idle task.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – N
  * State - Running (Core N)
- * 
+ *
  * Suspend task (T1)
- * 
+ *
  * Task (T1)	        Task (TN)
  * Priority – 1         Priority – 1
  * State - Suspended	State - Running (Core N)
- * 
+ *
  * Resume task (T1)
- * 
+ *
  * Task (TN)
  * Priority – N
  * State - Running (Core N)
  */
 void test_task_suspend_all_cores_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create tasks of equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Suspend task T0 */
-    vTaskSuspend( xTaskHandles[0] );
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
     /* Verify the task has been suspended */
-    verifySmpTask( &xTaskHandles[0], eSuspended, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eSuspended, -1 );
 
     /* Verify all other tasks are running */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the idle task is running on core 0 */
-    verifyIdleTask(0, 0);
+    verifyIdleTask( 0, 0 );
 
     /* Resume task T0 */
-    vTaskResume( xTaskHandles[0] );
-    
+    vTaskResume( xTaskHandles[ 0 ] );
+
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1505,49 +1565,50 @@ void test_task_suspend_all_cores_equal_priority( void )
  * that when the high priority task is suspended the low priority tasks will
  * enter the running state. When the high priority task is resumed, each low
  * priority task will return to the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 2               Priority – 1
- * State - Running (Core 0)	  State - Ready 
- * 
+ * State - Running (Core 0)	  State - Ready
+ *
  * Suspend task (T1)
- * 
+ *
  * Task (T1)	       Task (TN)
  * Priority – 2        Priority – 1
  * State - Suspended   State - Running (Core N)
- * 
+ *
  * Resume task (T1)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
  */
 void test_task_suspend_all_cores_different_priority_suspend_high( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i, xCoreToRunTask;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     /* SMP cores start with idle task. Idle task will yield itself when first time it runs
@@ -1560,14 +1621,15 @@ void test_task_suspend_all_cores_different_priority_suspend_high( void )
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
     /* The task running status when xTaskHandles[0] suspend ifself on Core 0.
@@ -1579,15 +1641,15 @@ void test_task_suspend_all_cores_different_priority_suspend_high( void )
      * ...
      * Core N-1 will choose xIdleTaskHandles[N-1] since it is the first idle task in ready queue.
      */
-    vTaskSuspend(xTaskHandles[0]);
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
     /* Verify the suspened task is not running. */
-    verifySmpTask( &xTaskHandles[0], eSuspended, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eSuspended, -1 );
 
     /* Verify all other tasks are in the running state */
-    for (i = 1; i < configNUMBER_OF_CORES; i++)
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
     {
-        verifySmpTask( &xTaskHandles[i], eRunning, i - 1 );
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i - 1 );
     }
 
     /* Verify the last core will run the last idle task. */
@@ -1606,22 +1668,24 @@ void test_task_suspend_all_cores_different_priority_suspend_high( void )
      * Core N-2 will choose xIdleTaskHandles[N-4]
      * Core 0 will choose xIdleTaskHandles[N-3]
      */
-    vTaskResume( xTaskHandles[0] );
+    vTaskResume( xTaskHandles[ 0 ] );
 
     /* Verify the high priority task is running */
     xCoreToRunTask = 1;
+
     if( xCoreToRunTask == ( configNUMBER_OF_CORES - 1 ) )
     {
         /* Core 1 is the last core. Since it is already running the idle task. It
          * won't be request to yield. Core 0 will choose the task to run. */
         xCoreToRunTask = 0;
     }
-    verifySmpTask( &xTaskHandles[0], eRunning, xCoreToRunTask );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++)
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, xCoreToRunTask );
+
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
     {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
     }
 
     /* Verify the idle task running status. */
@@ -1652,84 +1716,88 @@ void test_task_suspend_all_cores_different_priority_suspend_high( void )
  * created for each remaining available CPU core. This test will verify that
  * as each low priority task is suspended, the high priority task shall remain
  * in the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 2               Priority – 1
- * State - Running (Core 0)	  State - Ready 
- * 
+ * State - Running (Core 0)	  State - Ready
+ *
  * Suspend tasks (TN)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)  State - Suspended
- * 
+ *
  * Resume tasks (TN)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
  */
 void test_task_suspend_all_cores_different_priority_suspend_low( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Suspend low priority task */
-        vTaskSuspend( xTaskHandles[i] );
+        vTaskSuspend( xTaskHandles[ i ] );
 
         /* Verify T0 remains running on core 0 */
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
         /* Verify task T[i] is in the deleted state */
-        verifySmpTask( &xTaskHandles[i], eSuspended, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eSuspended, -1 );
     }
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Resume low priority task */
-        vTaskResume( xTaskHandles[i] );
+        vTaskResume( xTaskHandles[ i ] );
 
         /* Verify T0 remains running on core 0 */
-        verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+        verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
         /* Verify task T[i] is in the suspended state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
     }
 }
 
@@ -1739,81 +1807,85 @@ void test_task_suspend_all_cores_different_priority_suspend_low( void )
  * An additional low priority task shall be created. This test will verify that
  * when a high priority task is suspended the low priority task will remain in
  * the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 2               Priority – 1
- * State - Running (Core 0)	  State - Ready 
- * 
+ * State - Running (Core 0)	  State - Ready
+ *
  * Suspend tasks (T1)
- * 
+ *
  * Task (T1)	       Task (TN + 1)
  * Priority – 2        Priority – 1
  * State - Suspended   State - Ready
- * 
+ *
  * Resume tasks (T1)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
  */
 void test_task_suspend_all_cores_high_priority_suspend( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a task for each CPU core at high priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all high priority tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is ready */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Suspend the high priority task */
-    vTaskSuspend( xTaskHandles[0] );
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
     /* Verify the task is suspended */
-    verifySmpTask( &xTaskHandles[0], eSuspended, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eSuspended, -1 );
 
     /* Verify the idle task is running on core 0 */
-    verifyIdleTask(0, 0);
+    verifyIdleTask( 0, 0 );
 
     /* Verify all high priority tasks remain running */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Resume the high priority task */
-    vTaskResume( xTaskHandles[0] );
+    vTaskResume( xTaskHandles[ 0 ] );
 
     /* Verify all high priority tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1824,69 +1896,71 @@ void test_task_suspend_all_cores_high_priority_suspend( void )
  * verify that when a running task is suspended the ready task will move to
  * the running state. When the suspended task is resumed, it shall enter the
  * ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)
  * Priority – 1   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 1               Priority – 1
- * State - Running (Core N)	  State - Ready 
- * 
+ * State - Running (Core N)	  State - Ready
+ *
  * Suspend tasks (T1)
- * 
+ *
  * Task (T1)	       Task (TN + 1)
  * Priority – 2        Priority – 1
  * State - Suspended   State - Running (Core 0)
- * 
+ *
  * Resume tasks (T1)
- * 
+ *
  * Task (T1)	   Task (TN)
  * Priority – 2    Priority – 1
  * State - Ready   State - Running (Core 0)
  */
-void test_task_suspend_all_cores_equal_priority_suspend_running ( void )
+void test_task_suspend_all_cores_equal_priority_suspend_running( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a task for each CPU core at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES + 1; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES + 1; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the remaining task is ready */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Suspend the task on core 0 */
-    vTaskSuspend( xTaskHandles[0] );
+    vTaskSuspend( xTaskHandles[ 0 ] );
 
-     /* Verify the last task is now running on core 0 */
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    /* Verify the last task is now running on core 0 */
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 
     /* Resume the task on core 0 */
-    vTaskResume( xTaskHandles[0] );
+    vTaskResume( xTaskHandles[ 0 ] );
 
     /* Verify task T0 is now in the ready state */
-    verifySmpTask( &xTaskHandles[0], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eReady, -1 );
 }
 
 /**
@@ -1894,75 +1968,79 @@ void test_task_suspend_all_cores_equal_priority_suspend_running ( void )
  * A task of equal priority will be created for each available CPU core. This
  * test will verify that when a task is blocked the CPU core will execute
  * the idle task.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – N
  * State - Running (Core N)
- * 
+ *
  * Block task (T1)
- * 
+ *
  * Task (T1)	        Task (TN)
  * Priority – 1         Priority – 1
- * State - Blocked   	State - Running (Core N)
- * 
+ * State - Blocked      State - Running (Core N)
+ *
  * Unblock task (T1)
- * 
+ *
  * Task (TN)
  * Priority – N
  * State - Running (Core N)
  */
 void test_task_blocked_all_cores_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create tasks of equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Block task T0 */
     vTaskDelay( 10 );
 
     /* Verify the task has been blocked */
-    verifySmpTask( &xTaskHandles[0], eBlocked, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eBlocked, -1 );
 
     /* Verify all other tasks are running */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the idle task is running on core 0 */
-    verifyIdleTask(0, 0);
+    verifyIdleTask( 0, 0 );
 
     /* Unblock task T0 */
-    xTaskAbortDelay( xTaskHandles[0] );
-    
+    xTaskAbortDelay( xTaskHandles[ 0 ] );
+
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -1973,92 +2051,97 @@ void test_task_blocked_all_cores_equal_priority( void )
  * that when the high priority task is blocked the low priority tasks will
  * enter the running state. When the high priority task is resumed, each low
  * priority task will return to the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (T1)	  Task (TN)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (T1)	              Task (TN)
  * Priority – 2               Priority – 1
- * State - Running (Core 0)	  State - Ready 
- * 
+ * State - Running (Core 0)	  State - Ready
+ *
  * Block task (T1)
- * 
+ *
  * Task (T1)	       Task (TN)
  * Priority – 2        Priority – 1
  * State - Blocked     State - Running (Core N)
- * 
+ *
  * Unblock task (T1)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
  */
 void test_task_blocked_all_cores_different_priority_block_high( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i, xCoreToRunTask;
 
     /* Create a single task at high priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[0] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ 0 ] );
 
     /* Create all remaining tasks at low priority */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify the high priority task is running */
-    verifySmpTask( &xTaskHandles[0], eRunning, 0 );
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, 0 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
-        
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
         /* Verify the idle task is running on all other CPU cores */
-        verifyIdleTask(i - 1, i);
+        verifyIdleTask( i - 1, i );
     }
 
     /* Block task T0 */
     vTaskDelay( 10 );
 
     /* Verify the task has been blocked */
-    verifySmpTask( &xTaskHandles[0], eBlocked, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eBlocked, -1 );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
         /* Verify all other tasks are in the running state */
-        verifySmpTask( &xTaskHandles[i], eRunning, i - 1 );
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i - 1 );
     }
 
     /* Unblock task T0 */
-    xTaskAbortDelay( xTaskHandles[0] );
+    xTaskAbortDelay( xTaskHandles[ 0 ] );
 
 /* Verify the high priority task is running */
     xCoreToRunTask = 1;
+
     if( xCoreToRunTask == ( configNUMBER_OF_CORES - 1 ) )
     {
         /* Core 1 is the last core. Since it is already running the idle task. It
          * won't be request to yield. Core 0 will choose the task to run. */
         xCoreToRunTask = 0;
     }
-    verifySmpTask( &xTaskHandles[0], eRunning, xCoreToRunTask );
 
-    for (i = 1; i < configNUMBER_OF_CORES; i++)
+    verifySmpTask( &xTaskHandles[ 0 ], eRunning, xCoreToRunTask );
+
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
     {
         /* Verify all other tasks are in the idle state */
-        verifySmpTask( &xTaskHandles[i], eReady, -1 );
+        verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
     }
 
     /* Verify the idle task running status. */
@@ -2089,81 +2172,85 @@ void test_task_blocked_all_cores_different_priority_block_high( void )
  * An additional low priority task shall be created. This test will verify that
  * when a high priority task is blocked the low priority task will remain in
  * the ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)
  * Priority – 2   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 2               Priority – 1
- * State - Running (Core 0)	  State - Ready 
- * 
+ * State - Running (Core 0)	  State - Ready
+ *
  * Block tasks (T1)
- * 
+ *
  * Task (T1)	       Task (TN + 1)
  * Priority – 2        Priority – 1
  * State - Blocked     State - Ready
- * 
+ *
  * Unblocked tasks (T1)
- * 
+ *
  * Task (T1)	             Task (TN)
  * Priority – 2              Priority – 1
  * State - Running (Core 0)	 State - Ready
  */
 void test_task_block_all_cores_high_priority_block( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a task for each CPU core at high priority */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single task at low priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all high priority tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the low priority task is ready */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Block the high priority task T0 */
     vTaskDelay( 10 );
 
     /* Verify the task is blocked */
-    verifySmpTask( &xTaskHandles[0], eBlocked, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eBlocked, -1 );
 
     /* Verify the idle task is running on core 0 */
-    verifyIdleTask(0, 0);
+    verifyIdleTask( 0, 0 );
 
     /* Verify all high priority tasks remain running */
-    for (i = 1; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 1; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Resume the high priority task */
-    xTaskAbortDelay( xTaskHandles[0] );
+    xTaskAbortDelay( xTaskHandles[ 0 ] );
 
     /* Verify all high priority tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 }
 
@@ -2174,67 +2261,69 @@ void test_task_block_all_cores_high_priority_block( void )
  * verify that when a running task is blocked the ready task will move to
  * the running state. When the blocked task is resumed, it shall enter the
  * ready state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           0
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores
  * greater than 1.
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	  Task (TN + 1)
  * Priority – 1   Priority – 1
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 1               Priority – 1
- * State - Running (Core N)	  State - Ready 
- * 
+ * State - Running (Core N)	  State - Ready
+ *
  * Block tasks (T1)
- * 
+ *
  * Task (T1)	       Task (TN + 1)
  * Priority – 2        Priority – 1
  * State - Blocked     State - Running (Core 0)
- * 
+ *
  * Unblock tasks (T1)
- * 
+ *
  * Task (T1)	   Task (TN)
  * Priority – 2    Priority – 1
  * State - Ready   State - Running (Core 0)
  */
-void test_task_block_all_cores_equal_priority_block_running ( void )
+void test_task_block_all_cores_equal_priority_block_running( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create a task for each CPU core at equal priority */
-    for (i = 0; i < configNUMBER_OF_CORES + 1; i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < configNUMBER_OF_CORES + 1; i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks are running */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the remaining task is ready */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Block the task on core 0 */
     vTaskDelay( 10 );
 
-     /* Verify the last task is now running on core 0 */
-    verifySmpTask( &xTaskHandles[i], eRunning, 0 );
+    /* Verify the last task is now running on core 0 */
+    verifySmpTask( &xTaskHandles[ i ], eRunning, 0 );
 
     /* Resume the task on core 0 */
-    xTaskAbortDelay( xTaskHandles[0] );
+    xTaskAbortDelay( xTaskHandles[ 0 ] );
 
     /* Verify task T0 is now in the ready state */
-    verifySmpTask( &xTaskHandles[0], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ 0 ], eReady, -1 );
 }

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/FreeRTOSConfig.h
@@ -94,8 +94,8 @@
 /* Run time stats gathering configuration options. */
 unsigned long ulGetRunTimeCounterValue( void ); /* Prototype of function that returns run time counter. */
 void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that initialises the run time counter. */
-#define configGENERATE_RUN_TIME_STATS    0
-#define portGET_RUN_TIME_COUNTER_VALUE()            ulGetRunTimeCounterValue()
+#define configGENERATE_RUN_TIME_STATS             0
+#define portGET_RUN_TIME_COUNTER_VALUE()    ulGetRunTimeCounterValue()
 #define portUSING_MPU_WRAPPERS                    0
 #define portHAS_STACK_OVERFLOW_CHECKING           0
 #define configENABLE_MPU                          0
@@ -153,6 +153,6 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
     #define sbSEND_COMPLETED( pxStreamBuffer )    vGenerateCoreBInterrupt( pxStreamBuffer )
 #endif /* configINCLUDE_MESSAGE_BUFFER_AMP_DEMO */
 
-#define INFINITE_LOOP                       vFakeInfiniteLoop
+#define INFINITE_LOOP    vFakeInfiniteLoop
 
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/covg_single_priority_timeslice_utest.c
@@ -181,6 +181,7 @@ void test_coverage_prvIdleTask_yield_for_idle_priority_task( void )
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+
         if( i < configNUMBER_OF_CORES )
         {
             pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
@@ -188,8 +189,9 @@ void test_coverage_prvIdleTask_yield_for_idle_priority_task( void )
         }
         else
         {
-            xTaskTCBs[ i ].xTaskRunState = -1;  /* Set run state to taskTASK_NOT_RUNNING. */
+            xTaskTCBs[ i ].xTaskRunState = -1; /* Set run state to taskTASK_NOT_RUNNING. */
         }
+
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
     }
 
@@ -291,6 +293,7 @@ void test_coverage_prvMinimalIdleTask_yield_for_idle_priority_task( void )
         xTaskTCBs[ i ].xStateListItem.pvOwner = &xTaskTCBs[ i ];
         xTaskTCBs[ i ].xStateListItem.pxContainer = &pxReadyTasksLists[ tskIDLE_PRIORITY ];
         xTaskTCBs[ i ].uxCoreAffinityMask = ( ( 1U << configNUMBER_OF_CORES ) - 1U );
+
         if( i < configNUMBER_OF_CORES )
         {
             pxCurrentTCBs[ i ] = &xTaskTCBs[ i ];
@@ -298,8 +301,9 @@ void test_coverage_prvMinimalIdleTask_yield_for_idle_priority_task( void )
         }
         else
         {
-            xTaskTCBs[ i ].xTaskRunState = -1;  /* Set run state to taskTASK_NOT_RUNNING. */
+            xTaskTCBs[ i ].xTaskRunState = -1; /* Set run state to taskTASK_NOT_RUNNING. */
         }
+
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
     }
 
@@ -337,6 +341,7 @@ void test_coverage_prvSelectHighestPriorityTask_not_schedule_none_idle_task( voi
     uint32_t i = 0;
 
     /* Setup the variables and structure. */
+
     /* Initialize the idle priority ready list and set top ready priority to higher
      * priority than idle. */
     vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
@@ -345,30 +350,30 @@ void test_coverage_prvSelectHighestPriorityTask_not_schedule_none_idle_task( voi
     uxCurrentNumberOfTasks = 0;
 
     /* Create one normal task to be inserted at the beginning of ready list. */
-    vCreateStaticTestTask( &xTaskTCBs[ 0 ],
-                           ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                           tskIDLE_PRIORITY,
-                           taskTASK_NOT_RUNNING,
-                           pdFALSE );
+    vCreateStaticTestTaskAffinity( &xTaskTCBs[ 0 ],
+                                   ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                   tskIDLE_PRIORITY,
+                                   taskTASK_NOT_RUNNING,
+                                   pdFALSE );
     listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ 0 ].xStateListItem );
 
     /* Create core numbers running idle task. */
     for( i = 1; i < ( configNUMBER_OF_CORES + 1 ); i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY,
-                               ( i - 1 ),
-                               pdTRUE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY,
+                                       ( i - 1 ),
+                                       pdTRUE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
     }
 
     /* Create one higher priority normal task running on core one. */
-    vCreateStaticTestTask( &xTaskTCBs[ i ],
-                           ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                           tskIDLE_PRIORITY + 1,
-                           1,
-                           pdFALSE );
+    vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                   ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                   tskIDLE_PRIORITY + 1,
+                                   1,
+                                   pdFALSE );
     listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ], &xTaskTCBs[ i ].xStateListItem );
 
     /* The original core 1 idle task now is not running. */
@@ -382,6 +387,7 @@ void test_coverage_prvSelectHighestPriorityTask_not_schedule_none_idle_task( voi
     prvSelectHighestPriorityTask( 0 );
 
     /* Validations.*/
+
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it is not an idle task and top priority is higher than idle. */
     TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
@@ -420,6 +426,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_yielding( void )
     uint32_t i = 0;
 
     /* Setup the variables and structure. */
+
     /* Initialize the idle priority ready list and set top ready priority to higher
      * priority than idle. */
     vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
@@ -430,22 +437,22 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_yielding( void )
     /* Create core numbers running idle task. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY,
-                               i,
-                               pdTRUE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY,
+                                       i,
+                                       pdTRUE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
     }
 
     /* Create two higher priority normal task. */
     for( i = configNUMBER_OF_CORES; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY + 1,
-                               taskTASK_NOT_RUNNING,
-                               pdFALSE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY + 1,
+                                       taskTASK_NOT_RUNNING,
+                                       pdFALSE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ], &xTaskTCBs[ i ].xStateListItem );
     }
 
@@ -472,6 +479,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_yielding( void )
     prvSelectHighestPriorityTask( 0 );
 
     /* Validations.*/
+
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. Task on core 1 is yielding. */
     TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
@@ -510,6 +518,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_state_invalid( voi
     uint32_t i = 0;
 
     /* Setup the variables and structure. */
+
     /* Initialize the idle priority ready list and set top ready priority to higher
      * priority than idle. */
     vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
@@ -520,22 +529,22 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_state_invalid( voi
     /* Create core numbers running idle task. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY,
-                               i,
-                               pdTRUE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY,
+                                       i,
+                                       pdTRUE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
     }
 
     /* Create two higher priority normal task. */
     for( i = configNUMBER_OF_CORES; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY + 1,
-                               taskTASK_NOT_RUNNING,
-                               pdFALSE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY + 1,
+                                       taskTASK_NOT_RUNNING,
+                                       pdFALSE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ], &xTaskTCBs[ i ].xStateListItem );
     }
 
@@ -562,6 +571,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_state_invalid( voi
     prvSelectHighestPriorityTask( 0 );
 
     /* Validations.*/
+
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. */
     TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );
@@ -598,6 +608,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_yield_pending( voi
     uint32_t i = 0;
 
     /* Setup the variables and structure. */
+
     /* Initialize the idle priority ready list and set top ready priority to higher
      * priority than idle. */
     vListInitialise( &( pxReadyTasksLists[ tskIDLE_PRIORITY ] ) );
@@ -608,22 +619,22 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_yield_pending( voi
     /* Create core numbers running idle task. */
     for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY,
-                               i,
-                               pdTRUE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY,
+                                       i,
+                                       pdTRUE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY ], &xTaskTCBs[ i ].xStateListItem );
     }
 
     /* Create two higher priority normal task. */
     for( i = configNUMBER_OF_CORES; i < ( configNUMBER_OF_CORES + 2 ); i++ )
     {
-        vCreateStaticTestTask( &xTaskTCBs[ i ],
-                               ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
-                               tskIDLE_PRIORITY + 1,
-                               taskTASK_NOT_RUNNING,
-                               pdFALSE );
+        vCreateStaticTestTaskAffinity( &xTaskTCBs[ i ],
+                                       ( ( 1U << configNUMBER_OF_CORES ) - 1U ),
+                                       tskIDLE_PRIORITY + 1,
+                                       taskTASK_NOT_RUNNING,
+                                       pdFALSE );
         listINSERT_END( &pxReadyTasksLists[ tskIDLE_PRIORITY + 1 ], &xTaskTCBs[ i ].xStateListItem );
     }
 
@@ -650,6 +661,7 @@ void test_coverage_prvSelectHighestPriorityTask_affinity_task_yield_pending( voi
     prvSelectHighestPriorityTask( 0 );
 
     /* Validations.*/
+
     /* T0 won't be selected to run after calling prvSelectHighestPriorityTask since
      * it can only runs on core 0 and core 1. Core 1 has yield pending. */
     TEST_ASSERT_NOT_EQUAL( &xTaskTCBs[ 0 ], pxCurrentTCBs[ 0 ] );

--- a/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/single_priority_timeslice/single_priority_timeslice_utest.c
@@ -88,30 +88,30 @@ void vApplicationMinimalIdleHook( void )
  * @brief AWS_IoT-FreeRTOS_SMP_TC-75
  * A task of equal priority will be created for each available CPU core. An
  * additional task will be created in the ready state. This test will verify
- * that as OS ticks are generated the ready task will be made to run on each 
+ * that as OS ticks are generated the ready task will be made to run on each
  * CPU core.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	    Task (TN + 1)
  * Priority – 1     Priority – 1
  * State - Ready	State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	               Task (TN + 1)
  * Priority – 1                Priority – 1
  * State - Running (Core N)	   State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       0
@@ -121,32 +121,34 @@ void vApplicationMinimalIdleHook( void )
  */
 void test_timeslice_verification_tasks_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES + 1 tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES + 1); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES + 1 ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify all configNUMBER_OF_CORES tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the last task is in the ready state */
-    verifySmpTask( &xTaskHandles[i], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
 
     /* Generate a tick for each configNUMBER_OF_CORES. This will cause each
-       task to be either moved to the ready state or the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++)
+     * task to be either moved to the ready state or the running state */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
     {
         xTaskIncrementTick_helper();
 
         /* Verify the last created task runs on each core by looping through the 0,1,2,3... cycle */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 }
 
@@ -156,58 +158,62 @@ void test_timeslice_verification_tasks_equal_priority( void )
  * except for one. This will leave a CPU core running the idle task. This test
  * will verify that as OS ticks are generated the tasks will remain on the same
  * CPU core.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN - 1)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN - 1)
  * Priority – 1
  * State - Running (Core N - 1)
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
- * 
+ *
  * Task (TN - 1)
  * Priority – 1
  * State - Running (Core N - 1)
  */
 void test_timeslice_verification_idle_core( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES - 1); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES - 1 ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
-    
+
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state prior to incrementing a tick */
-    for (i = 0; i < configNUMBER_OF_CORES -1 ; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES - 1; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* Verify the idle task is running on the last CPU Core */
-    verifyIdleTask(0, (configNUMBER_OF_CORES - 1));
+    verifyIdleTask( 0, ( configNUMBER_OF_CORES - 1 ) );
 
     /* Verify all tasks remain in the running state each time a tick is incremented */
-    for (i = 0; i < configNUMBER_OF_CORES ; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
-        for (int j = 0; j < configNUMBER_OF_CORES - 1; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, j );
+        for( int j = 0; j < configNUMBER_OF_CORES - 1; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
         }
     }
 }
@@ -218,65 +224,69 @@ void test_timeslice_verification_idle_core( void )
  * additional low priority task will be created in the ready state. This test
  * will verify that as OS ticks are generated all CPU cores will remain running
  * their original tasks and the ready task never enters the running state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	    Task (TN + 1)
  * Priority – 2     Priority – 1
  * State - Ready	State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 2               Priority – 1
  * State - Running (Core N)   State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 2               Priority – 1
  * State - Running (Core N)   State - Ready
  */
 void test_timeslice_verification_different_priority_tasks( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of high priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
-    
+
     /* Create a single low priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The remaining task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
     /* Verify all tasks remain in the running state each time a tick is incremented */
     /* The low priority task should never enter the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
-        
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, j );
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
         }
 
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
     }
 }
 
@@ -288,88 +298,92 @@ void test_timeslice_verification_different_priority_tasks( void )
  * their original tasks and the ready task never enters the running state. The
  * test will then increase the priority of the ready task and verify tasks now
  * begin to run on each CPU core.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	    Task (TN + 1)
  * Priority – 2     Priority – 1
  * State - Ready	State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 2               Priority – 1
  * State - Running (Core N)   State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 2               Priority – 1
  * State - Running (Core N)   State - Ready
- * 
+ *
  * Raise the priority of task TN + 1 and verify on each tick it executes on a
  * different CPU core
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       0
  * 2       1
  * 3       2
- * 4       3 
+ * 4       3
  */
 void test_priority_change_tasks_different_priority_raise_to_equal( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of high priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
-    /* Create a single low priority task */ 
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    /* Create a single low priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The remaining task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
     /* Verify all tasks remain in the running state each time a tick is incremented */
     /* The low priority task should never enter the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
-        
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, j );
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
         }
 
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
     }
 
     /* Raise the priority of the low priority task to match the running tasks */
-    vTaskPrioritySet( xTaskHandles[configNUMBER_OF_CORES], 2 );
+    vTaskPrioritySet( xTaskHandles[ configNUMBER_OF_CORES ], 2 );
 
     /* After the first tick the ready task will be running on the first CPU core */
-    for (i = 0; i < configNUMBER_OF_CORES; i++)
-    {        
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /* Verify the the last task has a increasing xTaskRunState as it will follow the cycle of 0,1,2,3...
          * the last state of -1 is omitted */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 }
 
@@ -380,90 +394,94 @@ void test_priority_change_tasks_different_priority_raise_to_equal( void )
  * will verify that as OS ticks are generated all tasks will execute on each
  * CPU core. The test will then lower the priority of the last task and verify
  * tasks now remain running on a dedicated CPU core.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)	    Task (TN + 1)
  * Priority – 2     Priority – 2
  * State - Ready	State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 2               Priority – 2
  * State - Running (Core N)   State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       0
  * 2       1
  * 3       2
  * 4       3
- * 
+ *
  * Lower the priority of task TN + 1
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
- * 
+ *
  * Task (TN)	              Task (TN + 1)
  * Priority – 2               Priority – 1
  * State - Running (Core N)   State - Ready
  */
 void test_priority_change_tasks_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
-    
-    /* Create a single equal priority task */ 
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
-    
+
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The remaining task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /* Verify the last created task runs on each core. */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 
     /* Lower the priority of the last task.
      * Before ready list : [ 1(0), 2(1), ..., N(N-1), 0 ]
      * After raedy list : [ 1(0), 2(1), ..., 0(N-1) ]
      */
-    vTaskPrioritySet( xTaskHandles[configNUMBER_OF_CORES], 1 );
+    vTaskPrioritySet( xTaskHandles[ configNUMBER_OF_CORES ], 1 );
 
     /* Verify all configNUMBER_OF_CORES tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
-        
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
         }
 
         /* Verify the low priority task remains in the ready state */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
     }
 }
 
@@ -472,37 +490,37 @@ void test_priority_change_tasks_equal_priority( void )
  * A task will be created for each available CPU core. This test will verify that as
  * OS ticks are generated all tasks will execute on a fixed CPU core. A new task
  * will be created. The test will then verify tasks now execute on each
- * available CPU core. 
- * 
+ * available CPU core.
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 1
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Running (Core N)
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Running (Core N)
- * 
+ *
  * Create a new task
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       0
@@ -512,37 +530,41 @@ void test_priority_change_tasks_equal_priority( void )
  */
 void test_task_create_tasks_equal_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks remain in the running state each time a tick is incremented */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
-        
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, j );
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
         }
-    } 
+    }
 
     /* Create a new task of equal priority */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[configNUMBER_OF_CORES] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ configNUMBER_OF_CORES ] );
 
     /* Verify the last created task runs on each core by looping through the 0,1,2,3... cycle */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
-        /* 
+        /*
          * Verify the the last task has a increasing xTaskRunState as it will follow the cycle of 0,1,2,3...
          * the last state of -1 is omitted
          */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 }
 
@@ -550,74 +572,79 @@ void test_task_create_tasks_equal_priority( void )
  * @brief AWS_IoT-FreeRTOS_SMP_TC-81
  * A high priority task will be created for each available CPU core. This test
  * will verify that as OS ticks are generated all tasks will execute on a fixed
- * CPU core. A new low priority task will be created. The test will then verify 
+ * CPU core. A new low priority task will be created. The test will then verify
  * the tasks remain executing on the original CPU cores and do not rotate.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Running (Core N)
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
- * 
+ *
  * Task (TN)
  * Priority – 2
  * State - Running (Core N)
- * 
+ *
  * Create a new low priority task
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (TN)                  Task (TN + 1)
  * Priority – 2               Priority – 1
  * State - Running (Core N)   State - Ready
  */
 void test_task_create_tasks_lower_priority( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     vTaskStartScheduler();
 
     /* Verify all tasks remain in the running state each time a tick is incremented */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
-        
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, j );
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
         }
-    } 
+    }
 
     /* Create a new low priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[configNUMBER_OF_CORES] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 1, &xTaskHandles[ configNUMBER_OF_CORES ] );
 
     /* Verify all tasks remain in the running state each time a tick is incremented */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
-        
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, j );
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, j );
         }
-    } 
+    }
 }
 
 /**
@@ -627,85 +654,89 @@ void test_task_create_tasks_lower_priority( void )
  * will verify that as OS ticks are generated all tasks will execute on each
  * CPU core. A task will be deleted. The test will then verify the tasks remain
  * executing on fixed CPU cores and do not rotate.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)      Task (TN + 1)
  * Priority – 2   Priority – 2
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)                  Task (TN + 1)
  * Priority – 2               Priority – 2
  * State - Running (Core N)   State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       0
  * 2       1
  * 3       2
  * 4       3
- * 
+ *
  * Delete the last created task
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
- * 
+ *
  */
 void test_task_delete_tasks_equal_priorities_delete_running_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
-    /* Create a single equal priority task */ 
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The remaining task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /* Verify the last created task runs on each core by looping through the 0,1,2,3... cycle */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 
     /* Delete last task.
      * Before ready list : [ 1(0), 2(1), ..., N(N-1), 0 ]
      * After ready list : [ 1(0), 2(1), ..., 0(N-1) ]
      */
-    vTaskDelete(xTaskHandles[configNUMBER_OF_CORES]);
+    vTaskDelete( xTaskHandles[ configNUMBER_OF_CORES ] );
 
     /* Verify all configNUMBER_OF_CORES tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
-        
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
         }
-    } 
+    }
 }
 
 /**
@@ -716,84 +747,88 @@ void test_task_delete_tasks_equal_priorities_delete_running_task( void )
  * CPU core. A task will be suspended. The test will then verify the tasks remain
  * executing on fixed CPU cores and do not rotate. When the suspended task is
  * resumed it will begin executing on each CPU core on each tick.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)      Task (TN + 1)
  * Priority – 2   Priority – 2
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)                  Task (TN + 1)
  * Priority – 2               Priority – 2
  * State - Running (Core N)   State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       0
  * 2       1
  * 3       2
  * 4       3
- * 
+ *
  * Suspend the last created task
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not change state.
- * 
+ *
  * Resume the suspended task. The tasks will now rotate to each CPU on each tick.
  */
 void test_task_suspend_running_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
-    /* Create a single equal priority task */ 
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
-    
+
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The remaining task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /* Verify the last created task runs on each core by looping through the 0,1,2,3... cycle */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 
     /* Suspend last task.
      * Before ready list : [ 1(0), 2(1), ..., N(N-1), 0 ]
      * After ready list : [ 1(0), 2(1), ..., 0(N-1) ]
      */
-    vTaskSuspend(xTaskHandles[configNUMBER_OF_CORES]);
+    vTaskSuspend( xTaskHandles[ configNUMBER_OF_CORES ] );
 
     /* Verify all tasks remain in the running state each time a tick is incremented */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
-        
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
-            verifySmpTask( &xTaskHandles[j], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
+
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
+            verifySmpTask( &xTaskHandles[ j ], eRunning, ( j + configNUMBER_OF_CORES - 1 ) % configNUMBER_OF_CORES );
         }
     }
 
@@ -801,17 +836,17 @@ void test_task_suspend_running_task( void )
      * Before ready list : [ 1(0), 2(1), ..., 0(N-1) ]
      * After ready list : [ 1(0), 2(1), ..., 0(N-1), N ]
      */
-    vTaskResume(xTaskHandles[configNUMBER_OF_CORES]);
+    vTaskResume( xTaskHandles[ configNUMBER_OF_CORES ] );
 
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-    
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /*
          * Verify the the last task has a increasing xTaskRunState as it will follow the cycle of 0,1,2,3...
          * the last state of -1 is omitted
          */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 }
 
@@ -822,37 +857,37 @@ void test_task_suspend_running_task( void )
  * will verify that as OS ticks are generated all tasks will execute on each
  * CPU core. A task will be blocked. The test will then verify the tasks remain
  * executing on fixed CPU cores and do not rotate.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)      Task (TN + 1)
  * Priority – 2   Priority – 2
  * State - Ready  State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)                  Task (TN + 1)
  * Priority – 2               Priority – 2
  * State - Running (Core N)   State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (0) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       0
  * 2       1
  * 3       2
  * 4       3
- * 
+ *
  * Block the task running on core 0, which is task 1.
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core. The tasks will not
  * change state.
  *
@@ -860,33 +895,35 @@ void test_task_suspend_running_task( void )
  */
 void test_task_block_running_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
-    /* Create a single equal priority task */   
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    /* Create a single equal priority task */
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The remaining task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /* Verify the last created task runs on each core by looping through the 0,1,2,3... cycle */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 
     /* Block the first task on core 0, which is task 1.
@@ -896,22 +933,24 @@ void test_task_block_running_task( void )
     vTaskDelay( configNUMBER_OF_CORES + 1 );
 
     /* Verify all configNUMBER_OF_CORES tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
-        for (int j = 0; j < configNUMBER_OF_CORES; j++) {
+        for( int j = 0; j < configNUMBER_OF_CORES; j++ )
+        {
             if( j == 0 )
             {
-                verifySmpTask( &xTaskHandles[j], eRunning, 0 );
+                verifySmpTask( &xTaskHandles[ j ], eRunning, 0 );
             }
             else if( j == 1 )
             {
                 /* Task 1 is currently been blocked. */
-                verifySmpTask( &xTaskHandles[j], eBlocked, -1 );
+                verifySmpTask( &xTaskHandles[ j ], eBlocked, -1 );
             }
             else
             {
-                verifySmpTask( &xTaskHandles[j], eRunning, j - 1 );
+                verifySmpTask( &xTaskHandles[ j ], eRunning, j - 1 );
             }
         }
     }
@@ -919,14 +958,15 @@ void test_task_block_running_task( void )
     /* After ( configNUMBER_OF_CORES + 1 ) ticks, the task 1 will be added back to
      * the ready list. Verfiy that the task 1 can be scheduled on each core when
      * xTaskIncrementTick is called. */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /*
          * Verify the the task 1 has a increasing xTaskRunState as it will follow the cycle of 0,1,2,3...
          * the last state of -1 is omitted
          */
-        verifySmpTask( &xTaskHandles[1], eRunning, i );
+        verifySmpTask( &xTaskHandles[ 1 ], eRunning, i );
     }
 }
 
@@ -935,71 +975,73 @@ void test_task_block_running_task( void )
  * A high priority task will be created for each available CPU core. An
  * additional high priority task will be created with affinity for the largest
  * numbered CPU core. This test will verify that as OS ticks are generated the
- * task with CPU affinity will either be in the ready state or running on the 
+ * task with CPU affinity will either be in the ready state or running on the
  * specified CPU core.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)        Task (TN + 1)
  * Priority – 2     Priority – 2
- * Affinity – None  Affinity – Last CPU Core 
+ * Affinity – None  Affinity – Last CPU Core
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)        Task (TN + 1)
  * Priority – 2     Priority – 2
- * Affinity – None  Affinity – Last CPU Core 
+ * Affinity – None  Affinity – Last CPU Core
  * State - Running  State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       3
  * 2      -1
  * 3       3
  * 4      -1
- * 
+ *
  */
 void test_task_affinity_verification( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
-        
+
     /* Create a single equal priority task with core affinity for the last CPU core */
-    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, (1 << (configNUMBER_OF_CORES - 1)), &xTaskHandles[i] );
+    xTaskCreateAffinitySet( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, ( 1 << ( configNUMBER_OF_CORES - 1 ) ), &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The remaining task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /* Verify the task is either in the ready state or running on the last CPU core */
-        int32_t core = (i % 2 == 0) ? (configNUMBER_OF_CORES - 1) : -1;
+        int32_t core = ( i % 2 == 0 ) ? ( configNUMBER_OF_CORES - 1 ) : -1;
 
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], (core == -1) ? eReady : eRunning, core );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], ( core == -1 ) ? eReady : eRunning, core );
     }
 }
 
@@ -1011,46 +1053,46 @@ void test_task_affinity_verification( void )
  * CPU core. The test will then set the last task to have affinity for the last
  * CPU core. The last task will only run on the last CPU core or be in the ready
  * state.
- * 
+ *
  * #define configRUN_MULTIPLE_PRIORITIES                    0
  * #define configUSE_TIME_SLICING                           1
  * #define configUSE_CORE_AFFINITY                          1
  * #define configNUMBER_OF_CORES                            (N > 1)
- * 
+ *
  * This test can be run with FreeRTOS configured for any number of cores greater than 1 .
- * 
+ *
  * Tasks are created prior to starting the scheduler.
- * 
+ *
  * Task (TN)        Task (TN + 1)
  * Priority – 2     Priority – 2
  * Affinity – None  Affinity – None
  * State - Ready    State - Ready
- * 
+ *
  * After calling vTaskStartScheduler()
- * 
+ *
  * Task (TN)        Task (TN + 1)
  * Priority – 2     Priority – 2
- * Affinity – None  Affinity – None 
+ * Affinity – None  Affinity – None
  * State - Running  State - Ready
- * 
+ *
  * Call xTaskIncrementTick() for each configured CPU core.
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1       0
  * 2       1
  * 3       2
  * 4       3
- * 
+ *
  * Set affinity for the last task to the last CPU core.
- * 
+ *
  * Task (TN)        Task (TN + 1)
  * Priority – 2     Priority – 2
- * Affinity – None  Affinity – Last CPU Core 
+ * Affinity – None  Affinity – Last CPU Core
  * State - Running  State - Ready
- * 
+ *
  * Verify the task only runs on the specified core or is in the ready state.
- * 
+ *
  * Task (TN + 1) when configNUMBER_OF_CORES = 4
  * Tick    Core
  * 1      -1
@@ -1060,48 +1102,50 @@ void test_task_affinity_verification( void )
  */
 void test_task_affinity_set_affinity_running_task( void )
 {
-    TaskHandle_t xTaskHandles[configNUMBER_OF_CORES + 1] = { NULL };
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
     uint32_t i;
 
     /* Create configNUMBER_OF_CORES tasks of equal priority */
-    for (i = 0; i < (configNUMBER_OF_CORES); i++) {
-        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    for( i = 0; i < ( configNUMBER_OF_CORES ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
     }
 
     /* Create a single equal priority task */
-    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[i] );
+    xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
 
     vTaskStartScheduler();
 
     /* Verify all tasks are in the running state */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        verifySmpTask( &xTaskHandles[i], eRunning, i );
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
     }
 
     /* The remaining task shall be in the ready state */
-    verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eReady, -1 );
+    verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eReady, -1 );
 
     /* After the first tick the ready task will be running on CPU core 1 */
     int32_t core = 1;
 
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /* Verify the last created task runs on each core by looping through the 0,1,2,3... cycle */
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], eRunning, i );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], eRunning, i );
     }
 
     /* Set CPU core affinity on the last task for the last CPU core */
-    vTaskCoreAffinitySet(xTaskHandles[configNUMBER_OF_CORES], 1 << ((configNUMBER_OF_CORES - 1)) );
+    vTaskCoreAffinitySet( xTaskHandles[ configNUMBER_OF_CORES ], 1 << ( ( configNUMBER_OF_CORES - 1 ) ) );
 
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
         xTaskIncrementTick_helper();
 
         /* Verify the task is either in the ready state or running on the last CPU core */
-        core = (i % 2 == 1) ? (configNUMBER_OF_CORES - 1) : -1 ;
+        core = ( i % 2 == 1 ) ? ( configNUMBER_OF_CORES - 1 ) : -1;
 
-        verifySmpTask( &xTaskHandles[configNUMBER_OF_CORES], (core == -1) ? eReady : eRunning, core );
+        verifySmpTask( &xTaskHandles[ configNUMBER_OF_CORES ], ( core == -1 ) ? eReady : eRunning, core );
     }
 }

--- a/FreeRTOS/Test/CMock/smp/smp_utest_common.c
+++ b/FreeRTOS/Test/CMock/smp/smp_utest_common.c
@@ -59,11 +59,11 @@ extern volatile TickType_t xPendedTicks;
 extern volatile BaseType_t xNumOfOverflows;
 extern volatile TickType_t xNextTaskUnblockTime;
 extern UBaseType_t uxTaskNumber;
-extern TaskHandle_t xIdleTaskHandles[configNUMBER_OF_CORES];
+extern TaskHandle_t xIdleTaskHandles[ configNUMBER_OF_CORES ];
 extern volatile UBaseType_t uxSchedulerSuspended;
 extern volatile UBaseType_t uxDeletedTasksWaitingCleanUp;
 extern List_t * volatile pxDelayedTaskList;
-extern volatile TCB_t *  pxCurrentTCBs[ configNUMBER_OF_CORES ];
+extern volatile TCB_t * pxCurrentTCBs[ configNUMBER_OF_CORES ];
 extern volatile BaseType_t xYieldPendings[ configNUMBER_OF_CORES ];
 
 static BaseType_t xCoreYields[ configNUMBER_OF_CORES ] = { 0 };
@@ -99,8 +99,8 @@ void vPortFree( void * pv )
 }
 
 StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
-                                             TaskFunction_t pxCode,
-                                             void * pvParameters )
+                                     TaskFunction_t pxCode,
+                                     void * pvParameters )
 {
     return pxTopOfStack;
 }
@@ -110,8 +110,9 @@ BaseType_t xPortStartScheduler( void )
     uint8_t i;
 
     /* Initialize each core with a task */
-    for (i = 0; i < configNUMBER_OF_CORES; i++) {
-        vTaskSwitchContext(i);
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        vTaskSwitchContext( i );
     }
 
     return pdTRUE;
@@ -119,10 +120,10 @@ BaseType_t xPortStartScheduler( void )
 
 void vPortEndScheduler( void )
 {
-    return;
 }
 
-void vFakePortYieldCoreStubCallback( int xCoreID, int cmock_num_calls )
+void vFakePortYieldCoreStubCallback( int xCoreID,
+                                     int cmock_num_calls )
 {
     BaseType_t xCoreInCritical = pdFALSE;
     BaseType_t xPreviousCoreId = xCurrentCoreId;
@@ -143,7 +144,9 @@ void vFakePortYieldCoreStubCallback( int xCoreID, int cmock_num_calls )
         /* If a is in the critical section, pend the core yield until the
          * task spinlock is released. */
         xCoreYields[ xCoreID ] = pdTRUE;
-    } else {
+    }
+    else
+    {
         /* No task is in the critical section. We can yield this core. */
         xCurrentCoreId = xCoreID;
         vTaskSwitchContext( xCurrentCoreId );
@@ -193,18 +196,19 @@ static void vYieldCores( void )
             vTaskSwitchContext( i );
         }
     }
+
     xCurrentCoreId = xPreviousCoreId;
 }
 
 unsigned int vFakePortGetCoreIDCallback( int cmock_num_calls )
 {
-    return ( unsigned int )xCurrentCoreId;
+    return ( unsigned int ) xCurrentCoreId;
 }
 
 void vFakePortGetISRLockCallback( int cmock_num_calls )
 {
     int i;
-    
+
     ( void ) cmock_num_calls;
 
     /* Ensure that no other core is in the critical section. */
@@ -264,11 +268,13 @@ void vFakePortReleaseTaskLockCallback( int cmock_num_calls )
 UBaseType_t vFakePortEnterCriticalFromISRCallback( int cmock_num_calls )
 {
     UBaseType_t uxSavedInterruptState;
+
     uxSavedInterruptState = vTaskEnterCriticalFromISR();
     return uxSavedInterruptState;
 }
 
-void vFakePortExitCriticalFromISRCallback( UBaseType_t uxSavedInterruptState, int cmock_num_calls )
+void vFakePortExitCriticalFromISRCallback( UBaseType_t uxSavedInterruptState,
+                                           int cmock_num_calls )
 {
     vTaskExitCriticalFromISR( uxSavedInterruptState );
     /* Simulate yield cores when leaving the critical section. */
@@ -279,7 +285,7 @@ void vFakePortExitCriticalFromISRCallback( UBaseType_t uxSavedInterruptState, in
 
 void commonSetUp( void )
 {
-    vFakePortYieldCore_StubWithCallback( vFakePortYieldCoreStubCallback) ;
+    vFakePortYieldCore_StubWithCallback( vFakePortYieldCoreStubCallback );
     vFakePortYield_StubWithCallback( vFakePortYieldStubCallback );
 
     vFakePortEnterCriticalSection_StubWithCallback( vFakePortEnterCriticalSectionCallback );
@@ -302,21 +308,21 @@ void commonSetUp( void )
     ulFakePortSetInterruptMaskFromISR_IgnoreAndReturn( 0 );
     vFakePortClearInterruptMaskFromISR_Ignore();
 
-    vFakePortDisableInterrupts_IgnoreAndReturn(1);
+    vFakePortDisableInterrupts_IgnoreAndReturn( 1 );
     vFakePortRestoreInterrupts_Ignore();
-    xTimerCreateTimerTask_IgnoreAndReturn(1);
-    vFakePortCheckIfInISR_IgnoreAndReturn(0);
+    xTimerCreateTimerTask_IgnoreAndReturn( 1 );
+    vFakePortCheckIfInISR_IgnoreAndReturn( 0 );
     vPortCurrentTaskDying_Ignore();
     portSetupTCB_CB_Ignore();
-    ulFakePortSetInterruptMask_IgnoreAndReturn(0);
+    ulFakePortSetInterruptMask_IgnoreAndReturn( 0 );
     vFakePortClearInterruptMask_Ignore();
 
     memset( &pxReadyTasksLists, 0x00, configMAX_PRIORITIES * sizeof( List_t ) );
     memset( &xDelayedTaskList1, 0x00, sizeof( List_t ) );
     memset( &xDelayedTaskList2, 0x00, sizeof( List_t ) );
-    memset( &xIdleTaskHandles, 0x00, (configNUMBER_OF_CORES * sizeof( TaskHandle_t )) );
-    memset( &pxCurrentTCBs, 0x00, (configNUMBER_OF_CORES * sizeof( TCB_t * )) );
-    memset( ( void * )&xYieldPendings, 0x00, ( configNUMBER_OF_CORES * sizeof( BaseType_t ) ) );
+    memset( &xIdleTaskHandles, 0x00, ( configNUMBER_OF_CORES * sizeof( TaskHandle_t ) ) );
+    memset( &pxCurrentTCBs, 0x00, ( configNUMBER_OF_CORES * sizeof( TCB_t * ) ) );
+    memset( ( void * ) &xYieldPendings, 0x00, ( configNUMBER_OF_CORES * sizeof( BaseType_t ) ) );
 
     uxDeletedTasksWaitingCleanUp = 0;
     uxCurrentNumberOfTasks = ( UBaseType_t ) 0U;
@@ -338,30 +344,32 @@ void commonSetUp( void )
 
 void commonTearDown( void )
 {
-
 }
 
 /* ==========================  Helper functions =========================== */
 
-void vSmpTestTask( void *pvParameters )
+void vSmpTestTask( void * pvParameters )
 {
 }
 
-void verifySmpTask( TaskHandle_t * xTaskHandle, eTaskState eCurrentState, TaskRunning_t xTaskRunState)
+void verifySmpTask( TaskHandle_t * xTaskHandle,
+                    eTaskState eCurrentState,
+                    TaskRunning_t xTaskRunState )
 {
     TaskStatus_t xTaskDetails;
 
-    vTaskGetInfo(*xTaskHandle, &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( *xTaskHandle, &xTaskDetails, pdTRUE, eInvalid );
     TEST_ASSERT_EQUAL_INT_MESSAGE( xTaskRunState, xTaskDetails.xHandle->xTaskRunState, "Task Verification Failed: Incorrect xTaskRunState" );
     TEST_ASSERT_EQUAL_INT_MESSAGE( eCurrentState, xTaskDetails.eCurrentState, "Task Verification Failed: Incorrect eCurrentState" );
 }
 
-void verifyIdleTask( BaseType_t index, TaskRunning_t xTaskRunState)
+void verifyIdleTask( BaseType_t index,
+                     TaskRunning_t xTaskRunState )
 {
     TaskStatus_t xTaskDetails;
     int ret;
 
-    vTaskGetInfo(xIdleTaskHandles[index], &xTaskDetails, pdTRUE, eInvalid );
+    vTaskGetInfo( xIdleTaskHandles[ index ], &xTaskDetails, pdTRUE, eInvalid );
     #ifdef configIDLE_TASK_NAME
         ret = strncmp( xTaskDetails.xHandle->pcTaskName, configIDLE_TASK_NAME, strlen( configIDLE_TASK_NAME ) );
     #else
@@ -394,32 +402,22 @@ void xTaskIncrementTick_helper( void )
     taskEXIT_CRITICAL_FROM_ISR( uxSavedInterruptState );
 }
 
-#if ( configUSE_CORE_AFFINITY == 1 )
-    void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
-                                UBaseType_t uxCoreAffinityMask,
-                                UBaseType_t uxPriority,
-                                BaseType_t xTaskRunState,
-                                BaseType_t xTaskIsIdle )
-#else
-    void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
-                                UBaseType_t uxPriority,
-                                BaseType_t xTaskRunState,
-                                BaseType_t xTaskIsIdle )
-#endif
+void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
+                            UBaseType_t uxPriority,
+                            BaseType_t xTaskRunState,
+                            BaseType_t xTaskIsIdle )
 {
-    TCB_t * pxTaskTCB = ( TCB_t * )xTaskHandle;
+    TCB_t * pxTaskTCB = ( TCB_t * ) xTaskHandle;
 
     pxTaskTCB->xStateListItem.pvOwner = pxTaskTCB;
-    #if ( configUSE_CORE_AFFINITY == 1 )
-        pxTaskTCB->uxCoreAffinityMask = uxCoreAffinityMask;
-    #endif
     pxTaskTCB->uxPriority = uxPriority;
 
     /* Also assign pxCurrentTCBs to the created task. */
     if( ( xTaskRunState >= 0 ) && ( xTaskRunState < configNUMBER_OF_CORES ) )
     {
-         pxCurrentTCBs[ xTaskRunState ] = pxTaskTCB;
+        pxCurrentTCBs[ xTaskRunState ] = pxTaskTCB;
     }
+
     pxTaskTCB->xTaskRunState = xTaskRunState;
 
     /* Set idle task attribute. */
@@ -436,25 +434,39 @@ void xTaskIncrementTick_helper( void )
     uxCurrentNumberOfTasks = uxCurrentNumberOfTasks + 1;
 }
 
-void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
-                                    StackType_t **ppxIdleTaskStackBuffer,
-                                    uint32_t *pulIdleTaskStackSize )
+#if ( configUSE_CORE_AFFINITY == 1 )
+    void vCreateStaticTestTaskAffinity( TaskHandle_t xTaskHandle,
+                                        UBaseType_t uxCoreAffinityMask,
+                                        UBaseType_t uxPriority,
+                                        BaseType_t xTaskRunState,
+                                        BaseType_t xTaskIsIdle )
+    {
+        TCB_t * pxTaskTCB = ( TCB_t * ) xTaskHandle;
+
+        vCreateStaticTestTask( xTaskHandle, uxPriority, xTaskRunState, xTaskIsIdle );
+        pxTaskTCB->uxCoreAffinityMask = uxCoreAffinityMask;
+    }
+#endif /* if ( configUSE_CORE_AFFINITY == 1 ) */
+
+void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                    StackType_t ** ppxIdleTaskStackBuffer,
+                                    uint32_t * pulIdleTaskStackSize )
 {
 /* If the buffers to be provided to the Idle task are declared inside this
-function then they must be declared static -- otherwise they will be allocated on
-the stack and so not exists after this function exits. */
-static StaticTask_t xIdleTaskTCB;
-static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+ * function then they must be declared static -- otherwise they will be allocated on
+ * the stack and so not exists after this function exits. */
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
 
     /* Pass out a pointer to the StaticTask_t structure in which the Idle task's
-    state will be stored. */
+     * state will be stored. */
     *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
 
     /* Pass out the array that will be used as the Idle task's stack. */
     *ppxIdleTaskStackBuffer = uxIdleTaskStack;
 
     /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
-    Note that, as the array is necessarily of type StackType_t,
-    configMINIMAL_STACK_SIZE is specified in words, not bytes. */
+     * Note that, as the array is necessarily of type StackType_t,
+     * configMINIMAL_STACK_SIZE is specified in words, not bytes. */
     *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
 }

--- a/FreeRTOS/Test/CMock/smp/smp_utest_common.h
+++ b/FreeRTOS/Test/CMock/smp/smp_utest_common.h
@@ -73,18 +73,20 @@ void commonTearDown( void );
 /**
  * @brief Verify task current and run states
  */
-void verifySmpTask( TaskHandle_t * xTaskHandle, eTaskState eCurrentState, 
-                        TaskRunning_t xTaskRunState);
+void verifySmpTask( TaskHandle_t * xTaskHandle,
+                    eTaskState eCurrentState,
+                    TaskRunning_t xTaskRunState );
 
 /**
  * @brief Verify the Idle task is executing on a specific core
  */
-void verifyIdleTask( BaseType_t index, TaskRunning_t xTaskRunState);
+void verifyIdleTask( BaseType_t index,
+                     TaskRunning_t xTaskRunState );
 
 /**
  * @brief Dummy task for test execution
  */
-void vSmpTestTask( void *pvParameters );
+void vSmpTestTask( void * pvParameters );
 
 /**
  * @brief Helper function to simulate calling xTaskIncrementTick in critical section.
@@ -99,17 +101,18 @@ void vSetCurrentCore( BaseType_t xCoreID );
 /**
  * @brief Helper function to create static test task.
  */
+void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
+                            UBaseType_t uxPriority,
+                            BaseType_t xTaskRunState,
+                            BaseType_t xTaskIsIdle );
+
 #if ( configUSE_CORE_AFFINITY == 1 )
-    void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
-                                UBaseType_t uxCoreAffinityMask,
-                                UBaseType_t uxPriority,
-                                BaseType_t xTaskRunState,
-                                BaseType_t xTaskIsIdle );
-#else
-    void vCreateStaticTestTask( TaskHandle_t xTaskHandle,
-                                UBaseType_t uxPriority,
-                                BaseType_t xTaskRunState,
-                                BaseType_t xTaskIsIdle );
+    void vCreateStaticTestTaskAffinity( TaskHandle_t xTaskHandle,
+                                        UBaseType_t uxCoreAffinityMask,
+                                        UBaseType_t uxPriority,
+                                        BaseType_t xTaskRunState,
+                                        BaseType_t xTaskIsIdle );
 #endif
+
 
 #endif /* SMP_UTEST_COMMON_H */

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_1.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_1.h
@@ -133,7 +133,10 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+#define configASSERT( x )                                     \
+    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
+         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
+    } while( 0 )
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 
@@ -141,8 +144,8 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 #define configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES    0
 
 #define configMINIMAL_SECURE_STACK_SIZE              ( 1024 )
-#define portALLOCATE_SECURE_CONTEXT         vFakePortAllocateSecureContext
+#define portALLOCATE_SECURE_CONTEXT                  vFakePortAllocateSecureContext
 
-#define INFINITE_LOOP                       vFakeInfiniteLoop
+#define INFINITE_LOOP                                vFakeInfiniteLoop
 
 #endif /* FREERTOS_CONFIG_H */

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_1.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_1.h
@@ -133,10 +133,9 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x )                                     \
-    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
-         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
-    } while( 0 )
+/* *INDENT-OFF* */
+#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+/* *INDENT-ON* */
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_2.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_2.h
@@ -128,7 +128,10 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+#define configASSERT( x )                                     \
+    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
+         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
+    } while( 0 )
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 #define configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES    0

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_2.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_2.h
@@ -128,10 +128,9 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x )                                     \
-    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
-         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
-    } while( 0 )
+/* *INDENT-OFF* */
+#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+/* *INDENT-ON* */
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 #define configUSE_LIST_DATA_INTEGRITY_CHECK_BYTES    0

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_assert.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_assert.h
@@ -132,7 +132,10 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+#define configASSERT( x )                                     \
+    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
+         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
+    } while( 0 )
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_assert.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_assert.h
@@ -132,10 +132,9 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x )                                     \
-    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
-         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
-    } while( 0 )
+/* *INDENT-OFF* */
+#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+/* *INDENT-ON* */
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_assert_stack.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_assert_stack.h
@@ -132,7 +132,10 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+#define configASSERT( x )                                     \
+    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
+         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
+    } while( 0 )
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 

--- a/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_assert_stack.h
+++ b/FreeRTOS/Test/CMock/tasks/FreeRTOSConfig_assert_stack.h
@@ -132,10 +132,9 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x )                                     \
-    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
-         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
-    } while( 0 )
+/* *INDENT-OFF* */
+#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+/* *INDENT-ON* */
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 

--- a/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_1_utest.c
@@ -71,7 +71,7 @@ extern volatile BaseType_t xSchedulerRunning;
 extern volatile TickType_t xPendedTicks;
 #if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern volatile BaseType_t xYieldPendings[];
-    #define xYieldPending   xYieldPendings[ 0 ]
+    #define xYieldPending    xYieldPendings[ 0 ]
 #else
     extern volatile BaseType_t xYieldPending;
 #endif
@@ -80,7 +80,7 @@ extern UBaseType_t uxTaskNumber;
 extern volatile TickType_t xNextTaskUnblockTime;
 #if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern TaskHandle_t xIdleTaskHandles[];
-    #define xIdleTaskHandle   xIdleTaskHandles[ 0 ]
+    #define xIdleTaskHandle    xIdleTaskHandles[ 0 ]
 #else
     extern TaskHandle_t xIdleTaskHandle;
 #endif
@@ -123,7 +123,7 @@ extern volatile UBaseType_t uxSchedulerSuspended;
 /**
  * @brief CException code for when a configASSERT should be intercepted.
  */
-#define configASSERT_E                       0xAA101
+#define configASSERT_E                  0xAA101
 
 /* ===========================  GLOBAL VARIABLES  =========================== */
 static StaticTask_t xIdleTaskTCB;
@@ -349,7 +349,7 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock (void )
+void vFakePortReleaseTaskLock( void )
 {
     HOOK_DIAG();
 }
@@ -1027,6 +1027,7 @@ void test_prvCheckTasksWaitingTermination_no_waiting_task( void )
     prvCheckTasksWaitingTermination();
 
     /* Validation. */
+
     /* No task is waiting to be cleand up. Nothing will be updated in this API. This
      * test case shows its result in the coverage report. */
 }
@@ -2656,15 +2657,15 @@ void test_xTaskCatchUpTicks( void )
     ptcb = task_handle;
     uxSchedulerSuspended = pdFALSE;
 
-    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn(pdTRUE);
-    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn(pdTRUE);
-    listCURRENT_LIST_LENGTH_ExpectAnyArgsAndReturn(0);
+    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
+    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
+    listCURRENT_LIST_LENGTH_ExpectAnyArgsAndReturn( 0 );
 
     /* API Call */
     ret_taskCatchUpTicks = xTaskCatchUpTicks( 1 );
     /* Validations */
     TEST_ASSERT_EQUAL( pdFALSE, ret_taskCatchUpTicks );
-    //TEST_ASSERT_EQUAL( pdTRUE, ret_taskCatchUpTicks );
+    /*TEST_ASSERT_EQUAL( pdTRUE, ret_taskCatchUpTicks ); */
     uxSchedulerSuspended = pdTRUE;
 }
 
@@ -2910,6 +2911,7 @@ void test_xTaskIncrementTick_success_unblock_higher_prio_task( void )
     task_handle = create_task();
     create_task_priority = 1;
     task_handle2 = create_task();
+
     /* task_handle 2 will be added to pxDelayedTaskList later. To wakup a higher priority
      * task, uxPriority is set higher than current task, which is 2. */
     task_handle2->uxPriority = 3;

--- a/FreeRTOS/Test/CMock/tasks/tasks_2_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_2_utest.c
@@ -68,7 +68,7 @@ extern volatile BaseType_t xSchedulerRunning;
 extern volatile TickType_t xPendedTicks;
 #if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern volatile BaseType_t xYieldPendings[];
-    #define xYieldPending   xYieldPendings[ 0 ]
+    #define xYieldPending    xYieldPendings[ 0 ]
 #else
     extern volatile BaseType_t xYieldPending;
 #endif
@@ -77,7 +77,7 @@ extern UBaseType_t uxTaskNumber;
 extern volatile TickType_t xNextTaskUnblockTime;
 #if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern TaskHandle_t xIdleTaskHandles[];
-    #define xIdleTaskHandle   xIdleTaskHandles[ 0 ]
+    #define xIdleTaskHandle    xIdleTaskHandles[ 0 ]
 #else
     extern TaskHandle_t xIdleTaskHandle;
 #endif
@@ -86,7 +86,7 @@ extern volatile UBaseType_t uxSchedulerSuspended;
 /**
  * @brief CException code for when a configASSERT should be intercepted.
  */
-#define configASSERT_E                       0xAA101
+#define configASSERT_E    0xAA101
 
 
 /* ===========================  GLOBAL VARIABLES  =========================== */
@@ -409,7 +409,7 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock (void )
+void vFakePortReleaseTaskLock( void )
 {
     HOOK_DIAG();
 }

--- a/FreeRTOS/Test/CMock/tasks/tasks_assert_stack.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_assert_stack.c
@@ -51,7 +51,8 @@
 /**
  * @brief CException code for when a configASSERT should be intercepted.
  */
-#define configASSERT_E                       0xAA101
+#define configASSERT_E    0xAA101
+
 /**
  * @brief Expect a configASSERT from the function called.
  *  Break out of the called function when this occurs.
@@ -75,6 +76,7 @@
     } while( 0 )
 
 /* ============================  GLOBAL VARIABLES =========================== */
+
 /**
  * @brief Global counter for the number of assertions in code.
  */
@@ -287,7 +289,7 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock (void )
+void vFakePortReleaseTaskLock( void )
 {
     HOOK_DIAG();
 }
@@ -337,6 +339,7 @@ int suiteTearDown( int numFailures )
 }
 
 /* ========================  TEST CASES ===================================== */
+
 /*!
  * @brief This test ensures that the code asserts when the alignment of the
  *        stack (growth upwards) is not similar to the basetype alignment
@@ -344,12 +347,12 @@ int suiteTearDown( int numFailures )
 void test_xTaskCreateStatic_assert_stack_alignment( void )
 {
     TaskFunction_t xTFunc = NULL;
-    StaticTask_t xTaskBuffer[200];
+    StaticTask_t xTaskBuffer[ 200 ];
     StackType_t * xStackBuffer;
 
-    char xStackBuffer_unaligned[200];
+    char xStackBuffer_unaligned[ 200 ];
 
-    xStackBuffer = (StackType_t *) &xStackBuffer_unaligned[1];
+    xStackBuffer = ( StackType_t * ) &xStackBuffer_unaligned[ 1 ];
 
     EXPECT_ASSERT_BREAK( xTaskCreateStatic( xTFunc,
                                             NULL,
@@ -361,4 +364,3 @@ void test_xTaskCreateStatic_assert_stack_alignment( void )
 
     validate_and_clear_assertions();
 }
-

--- a/FreeRTOS/Test/CMock/tasks/tasks_assert_stack_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_assert_stack_utest.c
@@ -51,7 +51,8 @@
 /**
  * @brief CException code for when a configASSERT should be intercepted.
  */
-#define configASSERT_E                       0xAA101
+#define configASSERT_E    0xAA101
+
 /**
  * @brief Expect a configASSERT from the function called.
  *  Break out of the called function when this occurs.
@@ -75,6 +76,7 @@
     } while( 0 )
 
 /* ============================  GLOBAL VARIABLES =========================== */
+
 /**
  * @brief Global counter for the number of assertions in code.
  */
@@ -287,7 +289,7 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock (void )
+void vFakePortReleaseTaskLock( void )
 {
     HOOK_DIAG();
 }
@@ -337,6 +339,7 @@ int suiteTearDown( int numFailures )
 }
 
 /* ========================  TEST CASES ===================================== */
+
 /*!
  * @brief This test ensures that the code asserts when the alignment of the
  *        stack is not similar to the basetype alignment
@@ -344,17 +347,17 @@ int suiteTearDown( int numFailures )
 void test_xTaskCreateStatic_assert_stack_alignment( void )
 {
     TaskFunction_t xTFunc = NULL;
-    StaticTask_t xTaskBuffer[200];
+    StaticTask_t xTaskBuffer[ 200 ];
     StackType_t * xStackBuffer;
 
-    char xStackBuffer_unaligned[200];
+    char xStackBuffer_unaligned[ 200 ];
 
-    xStackBuffer = (StackType_t *) &xStackBuffer_unaligned[1];
+    xStackBuffer = ( StackType_t * ) &xStackBuffer_unaligned[ 1 ];
 
-    printf("normal  %p\n", xStackBuffer_unaligned );
-    printf("added 2 %p\n", &xStackBuffer_unaligned[1] );
+    printf( "normal  %p\n", xStackBuffer_unaligned );
+    printf( "added 2 %p\n", &xStackBuffer_unaligned[ 1 ] );
 
-    printf("added 1 %p\n", xStackBuffer);
+    printf( "added 1 %p\n", xStackBuffer );
 
     EXPECT_ASSERT_BREAK( xTaskCreateStatic( xTFunc,
                                             NULL,
@@ -366,4 +369,3 @@ void test_xTaskCreateStatic_assert_stack_alignment( void )
 
     validate_and_clear_assertions();
 }
-

--- a/FreeRTOS/Test/CMock/tasks/tasks_assert_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_assert_utest.c
@@ -55,12 +55,12 @@
 /**
  * @brief CException code for when a configASSERT should be intercepted.
  */
-#define configASSERT_E                       0xAA101
+#define configASSERT_E    0xAA101
 
 /**
  * @brief simulate up to 10 tasks: add more if needed
  * */
-#define TCB_ARRAY                       10
+#define TCB_ARRAY         10
 
 /**
  * @brief Expect a configASSERT from the function called.
@@ -85,6 +85,7 @@
     } while( 0 )
 
 /* ============================  GLOBAL VARIABLES =========================== */
+
 /**
  * @brief Global counter for the number of assertions in code.
  */
@@ -147,7 +148,7 @@ extern volatile UBaseType_t uxCurrentNumberOfTasks;
 
 #if ( defined( configNUMBER_OF_CORES ) && ( configNUMBER_OF_CORES == 1 ) )
     extern TaskHandle_t xIdleTaskHandles[];
-    #define xIdleTaskHandle   xIdleTaskHandles[ 0 ]
+    #define xIdleTaskHandle    xIdleTaskHandles[ 0 ]
 #else
     extern TaskHandle_t xIdleTaskHandle;
 #endif
@@ -194,6 +195,7 @@ static TaskHandle_t create_task()
     listSET_LIST_ITEM_VALUE_ExpectAnyArgs();
 
     pxPortInitialiseStack_ExpectAnyArgsAndReturn( stack );
+
     if( is_first_task )
     {
         for( int i = ( UBaseType_t ) 0U; i < ( UBaseType_t ) configMAX_PRIORITIES; i++ )
@@ -423,7 +425,7 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock (void )
+void vFakePortReleaseTaskLock( void )
 {
     HOOK_DIAG();
 }
@@ -484,20 +486,22 @@ int suiteTearDown( int numFailures )
 }
 
 /* ========================  TEST CASES ===================================== */
+
 /*!
  * @brief This function ensures that the code asserts if the handle name is
  *        greater than configMAX_TASK_NAME_LEN
  */
 void test_xTaskGetHandle_assert_large_handle_name( void )
 {
-    int bigSize = configMAX_TASK_NAME_LEN  + 5;
+    int bigSize = configMAX_TASK_NAME_LEN + 5;
     char handleName[ bigSize ];
-    int i ;
+    int i;
 
     for( i = 0; i < bigSize; ++i )
     {
-        handleName[i] = 'a';
+        handleName[ i ] = 'a';
     }
+
     handleName[ bigSize - 1 ] = '\0';
 
     EXPECT_ASSERT_BREAK( ( void ) xTaskGetHandle( handleName ) );
@@ -510,7 +514,7 @@ void test_xTaskGetHandle_assert_large_handle_name( void )
  */
 void test_xTaskResumeAll_assert_scheduler_not_started( void )
 {
-    EXPECT_ASSERT_BREAK( ( void ) xTaskResumeAll( ) );
+    EXPECT_ASSERT_BREAK( ( void ) xTaskResumeAll() );
 
     validate_and_clear_assertions();
 }
@@ -521,7 +525,7 @@ void test_vTaskGenericNotifyGiveFromISR_assert_xTaskNotify_NULL( void )
 
     EXPECT_ASSERT_BREAK( vTaskGenericNotifyGiveFromISR( NULL,
                                                         1,
-                                                        &pxHigherPriorityTaskWoken) );
+                                                        &pxHigherPriorityTaskWoken ) );
 
     validate_and_clear_assertions();
 }
@@ -530,11 +534,11 @@ void test_vTaskGenericNotifyGiveFromISR_assert_uxIndexToNotify_out_of_bound( voi
 {
     BaseType_t pxHigherPriorityTaskWoken;
 
-    TaskHandle_t xTaskToNotify = (TaskHandle_t )0x1234;
+    TaskHandle_t xTaskToNotify = ( TaskHandle_t ) 0x1234;
 
     EXPECT_ASSERT_BREAK( vTaskGenericNotifyGiveFromISR( xTaskToNotify,
                                                         configTASK_NOTIFICATION_ARRAY_ENTRIES + 1,
-                                                        &pxHigherPriorityTaskWoken) );
+                                                        &pxHigherPriorityTaskWoken ) );
 
     validate_and_clear_assertions();
 }
@@ -567,7 +571,7 @@ void test_vTaskDelete_assert_schedulerSuspended( void )
  */
 void test_vTaskDelayUntil_assert_pxPreviousWakeTime_NULL( void )
 {
-    EXPECT_ASSERT_BREAK( xTaskDelayUntil( NULL, 23) );
+    EXPECT_ASSERT_BREAK( xTaskDelayUntil( NULL, 23 ) );
 
     validate_and_clear_assertions();
 }
@@ -617,7 +621,7 @@ void test_vTaskDelay_assert_uxScheduelrSuspended_neq_1( void )
  * @brief This test ensures that the code asserts if uxSchedulerSuspended is not
  *        equal to 1
  */
-void test_eTaskGetState_assert_TCB_ne_NULL ( void )
+void test_eTaskGetState_assert_TCB_ne_NULL( void )
 {
     EXPECT_ASSERT_BREAK( eTaskGetState( NULL ) );
     validate_and_clear_assertions();
@@ -627,17 +631,17 @@ void test_eTaskGetState_assert_TCB_ne_NULL ( void )
  * @brief This test ensures that the code asserts if uxSchedulerSuspended is not
  *        equal to 1
  */
-void test_vTaskSuspend_assert_scheduler_suspended_neq_zero ( void )
+void test_vTaskSuspend_assert_scheduler_suspended_neq_zero( void )
 {
     TCB_t * ptcb = create_task();
 
     uxSchedulerSuspended = 1;
-    uxListRemove_ExpectAnyArgsAndReturn ( 1 );
+    uxListRemove_ExpectAnyArgsAndReturn( 1 );
     listLIST_ITEM_CONTAINER_ExpectAndReturn( &ptcb->xEventListItem, NULL );
     vListInsertEnd_ExpectAnyArgs();
     listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
 
-    EXPECT_ASSERT_BREAK( vTaskSuspend(ptcb) );
+    EXPECT_ASSERT_BREAK( vTaskSuspend( ptcb ) );
 
     validate_and_clear_assertions();
 }
@@ -704,7 +708,7 @@ void test_vTaskStartScheduler_assert_could_not_allocate_memory( void )
     listINSERT_END_ExpectAnyArgs();
 
     xTimerCreateTimerTask_ExpectAndReturn( errCOULD_NOT_ALLOCATE_REQUIRED_MEMORY );
-    EXPECT_ASSERT_BREAK(vTaskStartScheduler());
+    EXPECT_ASSERT_BREAK( vTaskStartScheduler() );
 
     validate_and_clear_assertions();
 }
@@ -715,7 +719,7 @@ void test_vTaskStartScheduler_assert_could_not_allocate_memory( void )
  */
 void test_pcTaskGetName_assert_xTaskToQuery_is_null( void )
 {
-    EXPECT_ASSERT_BREAK( pcTaskGetName(NULL));
+    EXPECT_ASSERT_BREAK( pcTaskGetName( NULL ) );
 
     validate_and_clear_assertions();
 }
@@ -774,7 +778,7 @@ void test_vTaskPlaceOnEventList_assert_pxEventList_null( void )
  */
 void test_vTaskPlaceOnUnorderedEventList_assert_pxEventList_null( void )
 {
-    EXPECT_ASSERT_BREAK( vTaskPlaceOnUnorderedEventList( NULL, 2, 3) );
+    EXPECT_ASSERT_BREAK( vTaskPlaceOnUnorderedEventList( NULL, 2, 3 ) );
     validate_and_clear_assertions();
 }
 
@@ -787,7 +791,7 @@ void test_vTaskPlaceOnUnorderedEventList_assert_scheduler_suspended_eq_zero( voi
 {
     List_t xEventList;
 
-    EXPECT_ASSERT_BREAK( vTaskPlaceOnUnorderedEventList (&xEventList, 2, 3) );
+    EXPECT_ASSERT_BREAK( vTaskPlaceOnUnorderedEventList( &xEventList, 2, 3 ) );
     validate_and_clear_assertions();
 }
 
@@ -797,7 +801,7 @@ void test_vTaskPlaceOnUnorderedEventList_assert_scheduler_suspended_eq_zero( voi
  */
 void test_vTaskPlaceOnEventListRestricted_assert_pxEventList_eq_NULL( void )
 {
-    EXPECT_ASSERT_BREAK( vTaskPlaceOnEventListRestricted (NULL, 2, 3) );
+    EXPECT_ASSERT_BREAK( vTaskPlaceOnEventListRestricted( NULL, 2, 3 ) );
 
     validate_and_clear_assertions();
 }
@@ -806,13 +810,13 @@ void test_vTaskPlaceOnEventListRestricted_assert_pxEventList_eq_NULL( void )
  * @brief This test ensures that the code asserts when the list head entry for
  *        xEventList is NULL
  */
-void test_xTaskRemoveFromEventList_assert_event_list_head_entry_null (void )
+void test_xTaskRemoveFromEventList_assert_event_list_head_entry_null( void )
 {
     List_t xEventList;
 
-    listGET_OWNER_OF_HEAD_ENTRY_ExpectAnyArgsAndReturn(NULL);
+    listGET_OWNER_OF_HEAD_ENTRY_ExpectAnyArgsAndReturn( NULL );
 
-    EXPECT_ASSERT_BREAK( xTaskRemoveFromEventList (&xEventList) );
+    EXPECT_ASSERT_BREAK( xTaskRemoveFromEventList( &xEventList ) );
 
     validate_and_clear_assertions();
 }
@@ -821,13 +825,13 @@ void test_xTaskRemoveFromEventList_assert_event_list_head_entry_null (void )
  * @brief This test ensures that the code asserts when
  * vTaskRemoveFromUnorderedEventList and the schedueler is not suspended
  */
-void test_vTaskRemoveFromUnorderedEventList_assert_scheduler_running ( void )
+void test_vTaskRemoveFromUnorderedEventList_assert_scheduler_running( void )
 {
     ListItem_t xEventListItem;
 
     uxSchedulerSuspended = pdFALSE;
 
-    EXPECT_ASSERT_BREAK( vTaskRemoveFromUnorderedEventList(&xEventListItem, 2) );
+    EXPECT_ASSERT_BREAK( vTaskRemoveFromUnorderedEventList( &xEventListItem, 2 ) );
 
     validate_and_clear_assertions();
 }
@@ -835,7 +839,7 @@ void test_vTaskRemoveFromUnorderedEventList_assert_scheduler_running ( void )
 /*!
  * @brief This test ensures that the code asserts when pxUnblockedTCB is null
  */
-void test_vTaskRemoveFromUnorderedEventList_assert_ ( void )
+void test_vTaskRemoveFromUnorderedEventList_assert_( void )
 {
     ListItem_t xEventListItem;
 
@@ -844,7 +848,7 @@ void test_vTaskRemoveFromUnorderedEventList_assert_ ( void )
     listSET_LIST_ITEM_VALUE_ExpectAnyArgs();
     listGET_LIST_ITEM_OWNER_ExpectAnyArgsAndReturn( NULL );
 
-    EXPECT_ASSERT_BREAK( vTaskRemoveFromUnorderedEventList(&xEventListItem, 2) );
+    EXPECT_ASSERT_BREAK( vTaskRemoveFromUnorderedEventList( &xEventListItem, 2 ) );
 
     validate_and_clear_assertions();
 }
@@ -888,7 +892,7 @@ void test_xTaskCheckForTimeOut_assert_pxTicksToWait_null( void )
  * @brief This test ensures that the code asserts when the passed tcb is not
  *        equal to the current tcb
  */
-void test_xTaskPriorityDisinherit_assert_tcp_neq_current_tcb(void)
+void test_xTaskPriorityDisinherit_assert_tcp_neq_current_tcb( void )
 {
     create_task();
     TCB_t * ptcb2 = create_task();
@@ -902,7 +906,7 @@ void test_xTaskPriorityDisinherit_assert_tcp_neq_current_tcb(void)
  * @brief This test ensures that the code asserts when xTaskPriorityDisinherit
  *        is called with no help mutexes
  */
-void test_xTaskPriorityDisinherit_assert_no_mutexes_are_held(void)
+void test_xTaskPriorityDisinherit_assert_no_mutexes_are_held( void )
 {
     TCB_t * ptcb = create_task();
 
@@ -917,7 +921,7 @@ void test_xTaskPriorityDisinherit_assert_no_mutexes_are_held(void)
  */
 void test_vTaskSetThreadLocalStoragePointer_assert_task_handle_null( void )
 {
-    EXPECT_ASSERT_BREAK( vTaskSetThreadLocalStoragePointer(NULL, 1, NULL) );
+    EXPECT_ASSERT_BREAK( vTaskSetThreadLocalStoragePointer( NULL, 1, NULL ) );
 
     validate_and_clear_assertions();
 }
@@ -932,13 +936,13 @@ void test_prvCheckTasksWaitingTermination_assert_out_of_bound_ucStaticallyAlloca
     create_task();
     TCB_t * ptcb = create_task();
 
-    ptcb->ucStaticallyAllocated  = 3; /* out of range value */
+    ptcb->ucStaticallyAllocated = 3; /* out of range value */
 
-    uxListRemove_ExpectAnyArgsAndReturn(pdTRUE);
-    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn(NULL);
-    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn(pdTRUE);
+    uxListRemove_ExpectAnyArgsAndReturn( pdTRUE );
+    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( NULL );
+    listLIST_IS_EMPTY_ExpectAnyArgsAndReturn( pdTRUE );
 
-    EXPECT_ASSERT_BREAK(vTaskDelete( ptcb ) );
+    EXPECT_ASSERT_BREAK( vTaskDelete( ptcb ) );
 
     validate_and_clear_assertions();
 }
@@ -1007,7 +1011,7 @@ void test_xTaskGenericNotify_assert_index_gte_config_array_entries( void )
     UBaseType_t uxIndex = configTASK_NOTIFICATION_ARRAY_ENTRIES + 2;
 
     EXPECT_ASSERT_BREAK( xTaskGenericNotify( ptcb, uxIndex, 23,
-                                             eSetBits, NULL) );
+                                             eSetBits, NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1017,7 +1021,6 @@ void test_xTaskGenericNotify_assert_index_gte_config_array_entries( void )
  */
 void test_xTaskGenericNotify_assert_null_task_to_notify( void )
 {
-
     UBaseType_t uxIndex = configTASK_NOTIFICATION_ARRAY_ENTRIES - 1;
 
     EXPECT_ASSERT_BREAK( xTaskGenericNotify( NULL, uxIndex,
@@ -1031,13 +1034,12 @@ void test_xTaskGenericNotify_assert_null_task_to_notify( void )
  */
 void test_xTaskGenericNotify_assert_default_action_tickcount_ne_zero( void )
 {
-
     TCB_t * ptcb = create_task();
     UBaseType_t uxIndex = configTASK_NOTIFICATION_ARRAY_ENTRIES - 1;
 
     xTickCount = 3;
     EXPECT_ASSERT_BREAK( xTaskGenericNotify( ptcb, uxIndex, 3,
-                                             eSetValueWithoutOverwrite  + 1,
+                                             eSetValueWithoutOverwrite + 1,
                                              NULL ) );
     validate_and_clear_assertions();
 }
@@ -1056,9 +1058,9 @@ void test_xTaskGenericNotify_assert( void )
 
     listREMOVE_ITEM_ExpectAnyArgs();
     listINSERT_END_ExpectAnyArgs();
-    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn((void*)1);
-    EXPECT_ASSERT_BREAK( xTaskGenericNotify (ptcb, uxIndex, 3,
-                                             eSetValueWithoutOverwrite  + 1,
+    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( ( void * ) 1 );
+    EXPECT_ASSERT_BREAK( xTaskGenericNotify( ptcb, uxIndex, 3,
+                                             eSetValueWithoutOverwrite + 1,
                                              NULL ) );
     validate_and_clear_assertions();
 }
@@ -1073,20 +1075,20 @@ void test_xTaskGenericNotifyFromISR_assert_index_gte_config_array_entries( void 
     UBaseType_t uxIndex = configTASK_NOTIFICATION_ARRAY_ENTRIES + 2;
 
     EXPECT_ASSERT_BREAK( xTaskGenericNotifyFromISR( ptcb, uxIndex, 23,
-                                             eSetBits, NULL, NULL) );
+                                                    eSetBits, NULL, NULL ) );
     validate_and_clear_assertions();
 }
+
 /*!
  * @brief This test ensures that the code asserts when the task to notify is
  *        null
  */
 void test_xTaskGenericNotifyFromISR_assert_null_task_to_notify( void )
 {
-
     UBaseType_t uxIndex = configTASK_NOTIFICATION_ARRAY_ENTRIES - 1;
 
     EXPECT_ASSERT_BREAK( xTaskGenericNotifyFromISR( NULL, uxIndex,
-                                             23, eSetBits, NULL, NULL ) );
+                                                    23, eSetBits, NULL, NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1096,14 +1098,13 @@ void test_xTaskGenericNotifyFromISR_assert_null_task_to_notify( void )
  */
 void test_xTaskGenericNotifyFromISR_assert_default_action_should_not_get( void )
 {
-
     TCB_t * ptcb = create_task();
     UBaseType_t uxIndex = configTASK_NOTIFICATION_ARRAY_ENTRIES - 1;
 
     xTickCount = 3;
     EXPECT_ASSERT_BREAK( xTaskGenericNotifyFromISR( ptcb, uxIndex, 3,
-                                             eSetValueWithoutOverwrite  + 1,
-                                             NULL, NULL ) );
+                                                    eSetValueWithoutOverwrite + 1,
+                                                    NULL, NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1119,10 +1120,10 @@ void test_xTaskGenericNotifyFromISR_assert( void )
     ptcb->ucNotifyState[ uxIndex ] = 1; /* taskWAITING_NOTIFICATION */
     xTickCount = 0;
 
-    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn((void*)1);
-    EXPECT_ASSERT_BREAK( xTaskGenericNotifyFromISR (ptcb, uxIndex, 3,
-                                             eSetValueWithoutOverwrite  + 1,
-                                             NULL, NULL ) );
+    listLIST_ITEM_CONTAINER_ExpectAnyArgsAndReturn( ( void * ) 1 );
+    EXPECT_ASSERT_BREAK( xTaskGenericNotifyFromISR( ptcb, uxIndex, 3,
+                                                    eSetValueWithoutOverwrite + 1,
+                                                    NULL, NULL ) );
     validate_and_clear_assertions();
 }
 
@@ -1132,8 +1133,7 @@ void test_xTaskGenericNotifyFromISR_assert( void )
  */
 void test_xTaskGenericNotifyStateClear_assert_index_gte_array_entries( void )
 {
-
-    EXPECT_ASSERT_BREAK(  xTaskGenericNotifyStateClear(NULL,
-                                   configTASK_NOTIFICATION_ARRAY_ENTRIES + 2) );
+    EXPECT_ASSERT_BREAK( xTaskGenericNotifyStateClear( NULL,
+                                                       configTASK_NOTIFICATION_ARRAY_ENTRIES + 2 ) );
     validate_and_clear_assertions();
 }

--- a/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
+++ b/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOS.h
@@ -1383,7 +1383,7 @@ typedef struct xSTATIC_TCB
 {
     void * pxDummy1;
     #if ( portUSING_MPU_WRAPPERS == 1 )
-        //xMPU_SETTINGS xDummy2;
+        /*xMPU_SETTINGS xDummy2; */
     #endif
     #if ( configUSE_CORE_AFFINITY == 1 ) && ( configNUMBER_OF_CORES > 1 )
         UBaseType_t uxDummy26;

--- a/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOSConfig.h
@@ -132,7 +132,10 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+#define configASSERT( x )                                     \
+    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
+         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
+    } while( 0 )
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 

--- a/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOSConfig.h
+++ b/FreeRTOS/Test/CMock/tasks/tasks_freertos/FreeRTOSConfig.h
@@ -132,10 +132,9 @@ void vConfigureTimerForRunTimeStats( void );    /* Prototype of function that in
 
 /* It is a good idea to define configASSERT() while developing.  configASSERT()
  * uses the same semantics as the standard C assert() macro. */
-#define configASSERT( x )                                     \
-    do { if( x ) { vFakeAssert( true, __FILE__, __LINE__ ); } \
-         else { vFakeAssert( false, __FILE__, __LINE__ ); }   \
-    } while( 0 )
+/* *INDENT-OFF* */
+#define configASSERT( x ) do {  if( x ) { vFakeAssert( true, __FILE__, __LINE__ );  } else { vFakeAssert( false, __FILE__, __LINE__ ); } } while( 0 )
+/* *INDENT-ON* */
 
 #define portREMOVE_STATIC_QUALIFIER                  1
 

--- a/FreeRTOS/Test/CMock/tasks/tasks_freertos/tasks_utest.c
+++ b/FreeRTOS/Test/CMock/tasks/tasks_freertos/tasks_utest.c
@@ -52,7 +52,8 @@
 /**
  * @brief CException code for when a configASSERT should be intercepted.
  */
-#define configASSERT_E                       0xAA101
+#define configASSERT_E    0xAA101
+
 /**
  * @brief Expect a configASSERT from the function called.
  *  Break out of the called function when this occurs.
@@ -76,6 +77,7 @@
     } while( 0 )
 
 /* ============================  GLOBAL VARIABLES =========================== */
+
 /**
  * @brief Global counter for the number of assertions in code.
  */
@@ -288,7 +290,7 @@ unsigned int vFakePortGetCoreID( void )
     return 0;
 }
 
-void vFakePortReleaseTaskLock (void )
+void vFakePortReleaseTaskLock( void )
 {
     HOOK_DIAG();
 }
@@ -342,8 +344,8 @@ int suiteTearDown( int numFailures )
 void test_xTaskCreateStatic_assert_static_task_eq_tcb_t( void )
 {
     TaskFunction_t xTFunc = NULL;
-    StaticTask_t xTaskBuffer[200];
-    StackType_t xStackBuffer[200];
+    StaticTask_t xTaskBuffer[ 200 ];
+    StackType_t xStackBuffer[ 200 ];
 
     EXPECT_ASSERT_BREAK( xTaskCreateStatic( xTFunc,
                                             NULL,

--- a/FreeRTOS/Test/CMock/timers/timers_1_utest.c
+++ b/FreeRTOS/Test/CMock/timers/timers_1_utest.c
@@ -225,7 +225,7 @@ static void xCallback_Test_2_end( TimerHandle_t xTimer )
  *
  * NumCalls is checked in the test assert.
  */
-static void vTaskYieldWithinAPI_Callback(int NumCalls)
+static void vTaskYieldWithinAPI_Callback( int NumCalls )
 {
     ( void ) NumCalls;
 


### PR DESCRIPTION
Fix uncrustify for SMP

Description
-----------
Check with the command
```
find FreeRTOS/Test/CMock \
\( -name ethernet -o -name drivers -o -path 'FreeRTOS/Test/CMock/CMock' \) \
-prune -false -o -name "*.[hc]" -exec uncrustify --check -c tools/uncrustify.cfg {} +
```

Fix with the command
```
find FreeRTOS/Test/CMock \
\( -name ethernet -o -name drivers -o -path 'FreeRTOS/Test/CMock/CMock' \) \
-prune -false -o -name "*.[hc]" -exec uncrustify --replace -c tools/uncrustify.cfg {} +
```

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
