### PR TITLE
Add raise running task priority test cases

### DIFF
--- a/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
+++ b/FreeRTOS/Test/CMock/smp/multiple_priorities_no_timeslice/multiple_priorities_no_timeslice_utest.c
@@ -633,6 +633,78 @@ void test_priority_change_tasks_different_priority_lower_to_lowest( void )
 }
 
 /**
+ * @brief AWS_IoT-FreeRTOS_SMP_TC-110
+ * A task of equal priority will be created for each available CPU core. An
+ * additional task will be created in the ready state at equal priority.
+ * This test will verify that when the priority of running task is raised all
+ * the other running tasks remain running.
+ *
+ * #define configRUN_MULTIPLE_PRIORITIES                    1
+ * #define configUSE_TIME_SLICING                           0
+ * #define configNUMBER_OF_CORES                            (N > 1)
+ *
+ * This test can be run with FreeRTOS configured for any number of cores
+ * greater than 1.
+ *
+ * Tasks are created prior to starting the scheduler.
+ *
+ * Task (T1)	    Task (TN)       Task (TN+1)
+ * Priority – 1     Priority – 1    Priority – 1
+ * State - Ready    State - Ready   State - Ready
+ *
+ * After calling vTaskStartScheduler()
+ *
+ * Task (T1)	        Task (TN)           Task (TN+1)
+ * Priority – 1         Priority – 1        Priority – 1
+ * State - Running      State - Running     State - Ready
+ *
+ * After calling vTaskPrioritySet() and raising the priority of task T1
+ *
+ * Task (T1)	        Task (TN)           Task (TN+1)
+ * Priority – 2         Priority – 1        Priority – 1
+ * State - Running      State - Running     State - Ready
+ */
+void test_priority_change_tasks_equal_priority_raise_additional_task( void )
+{
+    TaskHandle_t xTaskHandles[ configNUMBER_OF_CORES + 1 ] = { NULL };
+    uint32_t i;
+    TaskStatus_t xTaskDetails;
+
+    /* Create tasks at equal priority. */
+    for( i = 0; i < ( configNUMBER_OF_CORES + 1 ); i++ )
+    {
+        xTaskCreate( vSmpTestTask, "SMP Task", configMINIMAL_STACK_SIZE, NULL, 2, &xTaskHandles[ i ] );
+    }
+
+    vTaskStartScheduler();
+
+    /* Verify each task is in the running state. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* Verify the last task is in the ready state. */
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+
+    /* Raise the priority of a running task. */
+    vTaskPrioritySet( xTaskHandles[ 0 ], 2 );
+
+    /* Verify the priority has been changed. */
+    vTaskGetInfo( xTaskHandles[ 0 ], &xTaskDetails, pdTRUE, eInvalid );
+    TEST_ASSERT_EQUAL( 2, xTaskDetails.xHandle->uxPriority );
+
+    /* Verify each task is in the running state. */
+    for( i = 0; i < configNUMBER_OF_CORES; i++ )
+    {
+        verifySmpTask( &xTaskHandles[ i ], eRunning, i );
+    }
+
+    /* Verify the last task is in the ready state */
+    verifySmpTask( &xTaskHandles[ i ], eReady, -1 );
+}
+
+/**
  * @brief AWS_IoT-FreeRTOS_SMP_TC-41
  * A single task of high priority will be created. A low priority task will be
  * created for each remaining available CPU core. The test will first verify


### PR DESCRIPTION
Adding the functional tests to verify this kernel PR https://github.com/chinglee-iot/FreeRTOS-Kernel/pull/72

Description
-----------
* Add test_priority_change_task_high_priority_raise in single priority no timeslice. This test verify that raising the priority of a running task won't alter the idle tasks.
* Add test_priority_change_tasks_equal_priority_raise_additional_task in multiple priority no timeslice. This test verify that raising the priority of a running task won't alter other running tasks.

Filename | -- | -- | Line Coverage | -- | Functions | -- | Branches | --
-- | -- | -- | -- | -- | -- | -- | -- | --
event_groups.c |   |   | 95.7 % | 176 / 184 | 100.0 % | 16 / 16 | 72.0 % | 72 / 100
list.c |   |   | 100.0 % | 40 / 40 | 100.0 % | 5 / 5 | 100.0 % | 6 / 6
queue.c |   |   | 95.4 % | 726 / 761 | 100.0 % | 47 / 47 | 97.0 % | 456 / 470
stream_buffer.c |   |   | 94.2 % | 309 / 328 | 100.0 % | 26 / 26 | 95.5 % | 189 / 198
tasks.c |   |   | 99.5 % | 1461 / 1468 | 100.0 % | 96 / 96 | 95.1 % | 995 / 1046
timers.c |   |   | 100.0 % | 243 / 243 | 100.0 % | 30 / 30 | 96.2 % | 76 / 79

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
