### PR TITLE
Adding granular lock stream buffer tests

### DIFF
--- a/FreeRTOS/Test/CMock/smp/global_vars.h
+++ b/FreeRTOS/Test/CMock/smp/global_vars.h
@@ -211,5 +211,32 @@ typedef struct QueueDefinition /* The old naming convention is used to prevent b
  * name below to enable the use of older kernel aware debuggers. */
 typedef xQUEUE Queue_t;
 
+/* Structure that hold state information on the buffer. */
+typedef struct StreamBufferDef_t
+{
+    volatile size_t xTail;                       /* Index to the next item to read within the buffer. */
+    volatile size_t xHead;                       /* Index to the next item to write within the buffer. */
+    size_t xLength;                              /* The length of the buffer pointed to by pucBuffer. */
+    size_t xTriggerLevelBytes;                   /* The number of bytes that must be in the stream buffer before a task that is waiting for data is unblocked. */
+    volatile TaskHandle_t xTaskWaitingToReceive; /* Holds the handle of a task waiting for data, or NULL if no tasks are waiting. */
+    volatile TaskHandle_t xTaskWaitingToSend;    /* Holds the handle of a task waiting to send data to a message buffer that is full. */
+    uint8_t * pucBuffer;                         /* Points to the buffer itself - that is - the RAM that stores the data passed through the buffer. */
+    uint8_t ucFlags;
+
+    #if ( configUSE_TRACE_FACILITY == 1 )
+        UBaseType_t uxStreamBufferNumber; /* Used for tracing purposes. */
+    #endif
+
+    #if ( configUSE_SB_COMPLETED_CALLBACK == 1 )
+        StreamBufferCallbackFunction_t pxSendCompletedCallback;    /* Optional callback called on send complete. sbSEND_COMPLETED is called if this is NULL. */
+        StreamBufferCallbackFunction_t pxReceiveCompletedCallback; /* Optional callback called on receive complete.  sbRECEIVE_COMPLETED is called if this is NULL. */
+    #endif
+    UBaseType_t uxNotificationIndex;                               /* The index we are using for notification, by default tskDEFAULT_INDEX_TO_NOTIFY. */
+    #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) )
+        portSPINLOCK_TYPE xTaskSpinlock;
+        portSPINLOCK_TYPE xISRSpinlock;
+    #endif /* #if ( ( portUSING_GRANULAR_LOCKS == 1 ) && ( configNUMBER_OF_CORES > 1 ) ) */
+} StreamBuffer_t;
+
 
 #endif /* ifndef GLOBAL_VARS_H */

--- a/FreeRTOS/Test/CMock/smp/granular_lock/Makefile
+++ b/FreeRTOS/Test/CMock/smp/granular_lock/Makefile
@@ -16,7 +16,7 @@ PROJECT_DEPS_SRC    := list.c
 PROJECT_HEADER_DEPS :=  FreeRTOS.h
 
 # SUITE_UT_SRC: .c files that contain test cases (must end in _utest.c)
-SUITE_UT_SRC        :=  granular_lock_timers_utest.c granular_lock_queue_utest.c
+SUITE_UT_SRC        :=  granular_lock_timers_utest.c granular_lock_queue_utest.c granular_lock_stream_buffer_utest.c
 
 # SUITE_SUPPORT_SRC: .c files used for testing that do not contain test cases.
 # Paths are relative to PROJECT_DIR
@@ -27,7 +27,7 @@ SUITE_SUPPORT_SRC   += granular_lock_utest_common.c
 MOCK_FILES_FP   +=  $(KERNEL_DIR)/include/timers.h
 MOCK_FILES_FP   +=  $(UT_ROOT_DIR)/config/fake_assert.h
 MOCK_FILES_FP   +=  $(UT_ROOT_DIR)/config/fake_port.h
-MOCK_FILES_FP   +=  $(UT_ROOT_DIR)//smp/granular_lock/portmacro.h
+MOCK_FILES_FP   +=  $(UT_ROOT_DIR)/smp/granular_lock/portmacro.h
 
 # List any addiitonal flags needed by the preprocessor
 CPPFLAGS            +=

--- a/FreeRTOS/Test/CMock/smp/granular_lock/granular_lock_queue_utest.c
+++ b/FreeRTOS/Test/CMock/smp/granular_lock/granular_lock_queue_utest.c
@@ -53,6 +53,7 @@
 #define TEST_QUEUE_ITEM_SIZE    ( sizeof( uint32_t ) )
 
 /* ===========================  GLOBAL VARIABLES  =========================== */
+
 static QueueHandle_t xDynamicQueueHandle = NULL;
 static QueueHandle_t xStaticQueueHandle = NULL;
 
@@ -307,4 +308,213 @@ void test_granular_locks_dynamic_queue_lock_state_protection_vTaskPlaceOnEventLi
 {
     granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test(
         &xDynamicQueueHandle->xTaskSpinlock );
+}
+
+/* ==============================  Test Cases static allocated queue ============================== */
+
+void test_granular_locks_static_queue_critical_section_independence( void )
+{
+    granular_locks_critical_section_independence( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_mutual_exclusion( void )
+{
+    granular_locks_critical_section_mutual_exclusion( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_nesting( void )
+{
+    granular_locks_critical_section_nesting( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_deletion( void )
+{
+    granular_locks_critical_section_state_protection_deletion( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_suspension( void )
+{
+    granular_locks_critical_section_state_protection_suspension( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_deletion_suspension( void )
+{
+    granular_locks_critical_section_state_protection_deletion_suspension( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_suspension_deletion( void )
+{
+    granular_locks_critical_section_state_protection_suspension_deletion( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_suspension_resumption_test( void ) /*=> Currently fails */
+{
+    granular_locks_critical_section_state_protection_suspension_resumption_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnEventList_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_blocked_deletion_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnEventList_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_blocked_suspension_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnEventList_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_deletion_blocked_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnEventList_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_suspension_blocked_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_critical_section_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test( &xStaticQueueHandle->xTaskSpinlock, &xStaticQueueHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_independence( void )
+{
+    granular_locks_lock_independence( &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_mutual_exclusion( void )
+{
+    granular_locks_lock_mutual_exclusion( &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_deletion( void )
+{
+    granular_locks_lock_state_protection_deletion( &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_suspension( void )
+{
+    granular_locks_lock_state_protection_suspension( &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_deletion_suspension( void )
+{
+    granular_locks_lock_state_protection_deletion_suspension( &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_suspension_deletion( void )
+{
+    granular_locks_lock_state_protection_suspension_deletion( &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_suspension_resumption( void )
+{
+    granular_locks_lock_state_protection_suspension_resumption_test( &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnEventList_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_blocked_deletion_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnEventList_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_blocked_suspension_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnEventList_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_deletion_blocked_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnEventList_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_suspension_blocked_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test(
+        &xStaticQueueHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_queue_lock_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test(
+        &xStaticQueueHandle->xTaskSpinlock );
 }

--- a/FreeRTOS/Test/CMock/smp/granular_lock/granular_lock_stream_buffer_utest.c
+++ b/FreeRTOS/Test/CMock/smp/granular_lock/granular_lock_stream_buffer_utest.c
@@ -1,0 +1,520 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+/*! @file granular_lock_stream_buffer_utest.c */
+
+/* C runtime includes. */
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+/* Task includes */
+#include "FreeRTOS.h"
+#include "FreeRTOSConfig.h"
+#include "stream_buffer.h"
+
+/* Test includes. */
+#include "unity.h"
+#include "unity_memory.h"
+#include "../global_vars.h"
+#include "../granular_lock_utest_common.h"
+
+/* Mock includes. */
+#include "mock_fake_assert.h"
+#include "mock_fake_port.h"
+#include "mock_portmacro.h"
+
+/* ===========================  TEST MACROS  =========================== */
+
+#define TEST_BUFFER_SIZE_BYTES      ( 50U )
+#define TEST_TRIGGER_LEVEL_BYTES    ( 1U )
+
+/* ===========================  GLOBAL VARIABLES  =========================== */
+
+static StreamBufferHandle_t xDynamicStreamBufferHandle;
+static StreamBufferHandle_t xStaticStreamBufferHandle;
+static StaticStreamBuffer_t xStreamBufferStruct;
+
+static uint8_t pucStreamBufferStorageArea[ TEST_BUFFER_SIZE_BYTES + 1U ];
+
+/* ============================  Unity Fixtures  ============================ */
+
+/*! called before each testcase */
+void setUp( void )
+{
+    /* Use the common setup for the testing. */
+    granularLocksSetUp();
+
+    /* stream buffer specific initialization. */
+    xDynamicStreamBufferHandle = xStreamBufferCreate( TEST_BUFFER_SIZE_BYTES, TEST_TRIGGER_LEVEL_BYTES );
+    TEST_ASSERT_NOT_EQUAL( NULL, xDynamicStreamBufferHandle );
+
+    xStaticStreamBufferHandle = xStreamBufferCreateStatic( TEST_BUFFER_SIZE_BYTES,
+                                                           TEST_TRIGGER_LEVEL_BYTES,
+                                                           pucStreamBufferStorageArea,
+                                                           &xStreamBufferStruct );
+    TEST_ASSERT_NOT_EQUAL( NULL, xStaticStreamBufferHandle );
+}
+
+/*! called after each testcase */
+void tearDown( void )
+{
+    granularLocksTearDown();
+
+    vStreamBufferDelete( xDynamicStreamBufferHandle );
+    xDynamicStreamBufferHandle = NULL;
+
+    xStaticStreamBufferHandle = NULL;
+}
+
+/*! called at the beginning of the whole suite */
+void suiteSetUp()
+{
+}
+
+/*! called at the end of the whole suite */
+int suiteTearDown( int numFailures )
+{
+    return numFailures;
+}
+
+/* ==============================  Test Cases dynamic allocated stream buffer ============================== */
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_independence( void )
+{
+    granular_locks_critical_section_independence( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_mutual_exclusion( void )
+{
+    granular_locks_critical_section_mutual_exclusion( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_nesting( void )
+{
+    granular_locks_critical_section_nesting( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_deletion( void )
+{
+    granular_locks_critical_section_state_protection_deletion( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_suspension( void )
+{
+    granular_locks_critical_section_state_protection_suspension( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_deletion_suspension( void )
+{
+    granular_locks_critical_section_state_protection_deletion_suspension( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_suspension_deletion( void )
+{
+    granular_locks_critical_section_state_protection_suspension_deletion( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_suspension_resumption_test( void ) /*=> Currently fails */
+{
+    granular_locks_critical_section_state_protection_suspension_resumption_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventList_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_blocked_deletion_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventList_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_blocked_suspension_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventList_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_deletion_blocked_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventList_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_suspension_blocked_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test( &xDynamicStreamBufferHandle->xTaskSpinlock, &xDynamicStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_independence( void )
+{
+    granular_locks_lock_independence( &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_mutual_exclusion( void )
+{
+    granular_locks_lock_mutual_exclusion( &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_deletion( void )
+{
+    granular_locks_lock_state_protection_deletion( &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_suspension( void )
+{
+    granular_locks_lock_state_protection_suspension( &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_deletion_suspension( void )
+{
+    granular_locks_lock_state_protection_deletion_suspension( &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_suspension_deletion( void )
+{
+    granular_locks_lock_state_protection_suspension_deletion( &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_suspension_resumption( void )
+{
+    granular_locks_lock_state_protection_suspension_resumption_test( &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnEventList_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_blocked_deletion_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnEventList_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_blocked_suspension_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnEventList_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_deletion_blocked_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnEventList_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_suspension_blocked_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_dynamic_stream_buffer_lock_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test(
+        &xDynamicStreamBufferHandle->xTaskSpinlock );
+}
+
+/* ==============================  Test Cases dynamic allocated stream buffer ============================== */
+
+void test_granular_locks_static_stream_buffer_critical_section_independence( void )
+{
+    granular_locks_critical_section_independence( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_mutual_exclusion( void )
+{
+    granular_locks_critical_section_mutual_exclusion( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_nesting( void )
+{
+    granular_locks_critical_section_nesting( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_deletion( void )
+{
+    granular_locks_critical_section_state_protection_deletion( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_suspension( void )
+{
+    granular_locks_critical_section_state_protection_suspension( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_deletion_suspension( void )
+{
+    granular_locks_critical_section_state_protection_deletion_suspension( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_suspension_deletion( void )
+{
+    granular_locks_critical_section_state_protection_suspension_deletion( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_suspension_resumption_test( void ) /*=> Currently fails */
+{
+    granular_locks_critical_section_state_protection_suspension_resumption_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventList_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_blocked_deletion_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventList_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_blocked_suspension_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventList_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_deletion_blocked_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventList_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventList_suspension_blocked_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_critical_section_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test( void )
+{
+    granular_locks_critical_section_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test( &xStaticStreamBufferHandle->xTaskSpinlock, &xStaticStreamBufferHandle->xISRSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_independence( void )
+{
+    granular_locks_lock_independence( &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_mutual_exclusion( void )
+{
+    granular_locks_lock_mutual_exclusion( &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_deletion( void )
+{
+    granular_locks_lock_state_protection_deletion( &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_suspension( void )
+{
+    granular_locks_lock_state_protection_suspension( &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_deletion_suspension( void )
+{
+    granular_locks_lock_state_protection_deletion_suspension( &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_suspension_deletion( void )
+{
+    granular_locks_lock_state_protection_suspension_deletion( &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_suspension_resumption( void )
+{
+    granular_locks_lock_state_protection_suspension_resumption_test( &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnEventList_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_blocked_deletion_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnEventList_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_blocked_suspension_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_deletion_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_blocked_suspension_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_deletion_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_blocked_suspension_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnEventList_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_deletion_blocked_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnEventList_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventList_suspension_blocked_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_deletion_blocked_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnUnorderedEventList_suspension_blocked_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_deletion_blocked_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}
+
+void test_granular_locks_static_stream_buffer_lock_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked( void )
+{
+    granular_locks_lock_state_protection_vTaskPlaceOnEventListRestricted_suspension_blocked_test(
+        &xStaticStreamBufferHandle->xTaskSpinlock );
+}


### PR DESCRIPTION
<!--- Title -->

Description
-----------
* Adding granular lock stream buffer tests

Test Steps
-----------
```
cd FreeRTOS/FreeRTOS/Test/CMock
make smp
```

Currently only suspend/resume test due to lacking of implementation.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested my changes. No regression in existing tests.
- [ ] I have modified and/or added unit-tests to cover the code changes in this Pull Request.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
